### PR TITLE
.gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,8 @@ cython_debug/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -322,3 +323,6 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# Direnv
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,7 @@ cython_debug/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon?
 
 
 # Thumbnails

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -5,10 +5,17 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 iniconfig==2.0.0
+    # via pytest
 packaging==23.2
+    # via pytest
 pluggy==1.3.0
+    # via pytest
 pyserial==3.5
+    # via pnpq
 pytest==7.4.4
+    # via pnpq

--- a/requirements.lock
+++ b/requirements.lock
@@ -5,10 +5,17 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 iniconfig==2.0.0
+    # via pytest
 packaging==23.2
+    # via pytest
 pluggy==1.3.0
+    # via pytest
 pyserial==3.5
+    # via pnpq
 pytest==7.4.4
+    # via pnpq


### PR DESCRIPTION
Added `.envrc` into gitignore to ignore configuration files for direnv.

Additionally, the requirements lock file from `rye sync` is updated.