### PR TITLE
Return type hint in stub waveplate's initializer

### DIFF
--- a/src/pnpq/devices/waveplate_stub.py
+++ b/src/pnpq/devices/waveplate_stub.py
@@ -17,7 +17,7 @@ from pnpq.errors import (
 class WaveplateStub:
     """Stub Waveplate Device Class"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Stub Serial Number
         # TODO: Custom serial number from initializer
         self.device_sn: str = "stubwaveplate"

--- a/src/pnpq/devices/waveplate_stub.py
+++ b/src/pnpq/devices/waveplate_stub.py
@@ -58,7 +58,7 @@ class WaveplateStub:
             return
         raise WaveplateInvalidDegreeError(f"Invalid degree: {degree}. Degree must be in a range [0,360]")
 
-    def __stub_check_channel(self, chanid: int):
+    def __stub_check_channel(self, chanid: int) -> bool:
         return chanid in self.enabled_channels
 
     def __set_steps(self, steps: int) -> None:


### PR DESCRIPTION
Adds types hint `None` to return type of `__init__` for stub wave plate as mentioned in #33 