### PR TITLE
Ozoptics odl bug fix #34 and #35

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,7 +3,9 @@ from pnpq import Switch
 from pnpq import OdlThorlabs
 from pnpq import OdlOzOptics
 from pnpq.devices.optical_delay_line import OpticalDelayLine
+import logging
 
+logging.basicConfig(level=logging.DEBUG)
 print("Check OzOptics Odl")
 # wp = Waveplate(serial_number='00AAABBB')
 # wp = Waveplate()
@@ -17,8 +19,16 @@ print("Check OzOptics Odl")
 # print(OpticalDelayLine("/dev/test"))
 # print(OdlThorlabs())
 # tlodl = OdlThorlabs("/dev/ttyUSB0")
-ozodl = OdlThorlabs(serial_number="CKBEe12CJ06")
-ozodl.connect()
+ozodl = OdlOzOptics(serial_number="CKBEe12CJ06")
+ozodl.reconnect()
+
+ozodl.home()
+
+ozodl.move(20)
+ozodl.get_step()
+
+ozodl.home()
+ozodl.get_step()
 
 print(OdlOzOptics)
 # oz = OdlOzOptics(serial_number='CKBEe12CJ06')

--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ from pnpq import OdlThorlabs
 from pnpq import OdlOzOptics
 from pnpq.devices.optical_delay_line import OpticalDelayLine
 
-print("hello world")
+print("Check OzOptics Odl")
 # wp = Waveplate(serial_number='00AAABBB')
 # wp = Waveplate()
 # wp.connect()
@@ -17,9 +17,8 @@ print("hello world")
 # print(OpticalDelayLine("/dev/test"))
 # print(OdlThorlabs())
 # tlodl = OdlThorlabs("/dev/ttyUSB0")
-tlodl = OdlThorlabs(serial_number="28252054")
-tlodl.connect()
-
+ozodl = OdlThorlabs(serial_number="CKBEe12CJ06")
+ozodl.connect()
 
 print(OdlOzOptics)
 # oz = OdlOzOptics(serial_number='CKBEe12CJ06')

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -4,28 +4,54 @@
 import serial
 from serial import Serial
 from pnpq.devices.optical_delay_line import OpticalDelayLine
-import time
+import time, logging
+from pnpq.errors import DeviceDisconnectedError
 
 
 class OdlOzOptics(OpticalDelayLine):
+    max_move: int
+    """maximum length for moving odl from 0-position, the total path length will be 2x(max_move)"""
+
+    min_move: int
+    """minimum specified length for moving: usually zero"""
+
+    resolution: int
+    """represents minimum specified length for moving on the stage: usually zero"""
+
+    home_timeout: int
+    """required time for completing home in seconds"""
+
+    move_timeout: int
+    """required time for completing home in seconds"""
+
     def __init__(
         self,
         serial_port: str | None = None,
         serial_number: str | None = None,
         config_file=None,
+        max_move = int | None = None,
     ):
         super().__init__(serial_port, serial_number, config_file)
+        self.name = "OzOptics ODL"
+
         self.conn.baudrate = 9600
         """Basic Communication BaudRate"""
         self.resolution = 32768 / 5.08
         """32768 steps per motor revolution(5.08 mm = 2xDistance Travel or mirror travel per pitch 0.1 inch)"""
-
+        self.logger = logging.getLogger(f"{self}")
         self.command_terminate = "\r\n"
+        self.max_move = 50
+        self.min_move = 0
 
         try:
             self.conn.open()
         except:
             raise RuntimeError("Can not open OZ optic ODL device")
+
+    def __ensure_port_open(self) -> None:
+        if not self.conn.is_open:
+            self.logger.error("disconnected")
+            raise DeviceDisconnectedError(f"{self} is disconnected")
 
     def connect(self):
         if self.conn.is_open == 0:
@@ -35,14 +61,15 @@ class OdlOzOptics(OpticalDelayLine):
                 raise RuntimeError("Connection failed: " + str(err))
 
     def move(self, dist: float):
-        if not self.conn.is_open:
-            raise RuntimeError("Moving ODL failed: can not connect to ODL device")
-        if dist > 200 or dist < 0:
+        self.__ensure_port_open()
+
+        if dist > self.max_move or dist < self.min_move:
             raise Exception("Invalid Move Parameter")
         else:
             self.set_step(int(dist * self.resolution))
 
     def set_step(self, value):
+        self.__ensure_port_open()
         cmd = "S" + str(value)
         response = self.serial_command(cmd)
         return response
@@ -51,16 +78,19 @@ class OdlOzOptics(OpticalDelayLine):
         pass
 
     def home(self):
+        self.__ensure_port_open()
         cmd = "FH"
         response = self.serial_command(cmd, retries=1000)
         return response
 
     def get_serial(self):
+        self.__ensure_port_open()
         cmd = "V2"
         response = self.serial_command(cmd)
         return response.split("Done")[0].split("\r\n")[1]
 
     def get_device_info(self):
+        self.__ensure_port_open()
         cmd = "V1"
         response = self.serial_command(cmd)
         response = response.split("\r\n")[1]
@@ -69,84 +99,100 @@ class OdlOzOptics(OpticalDelayLine):
         return device_name, hwd_version
 
     def get_mfg_date(self):
+        self.__ensure_port_open()
         cmd = "d?"
         response = self.serial_command(cmd)
         date = response.split("\r\n")[1]
         return date
 
     def echo(self, on_off):
+        self.__ensure_port_open()
         cmd = "e" + str(on_off)
         response = self.serial_command(cmd)
         return response
 
     def reset(self):
+        self.__ensure_port_open()
         cmd = "RESET"
         response = self.serial_command(cmd)
         return response
 
     def oz_mode(self, on_off):  # on_off -> 0: OZ mode OFF | 1: OZ mode ON
+        self.__ensure_port_open()
         cmd = "OZ-SHS" + str(on_off)
         # cmd = '?'
         response = self.serial_command(cmd)
         return response
 
     def forward(self):
+        self.__ensure_port_open()
         cmd = "GF"
         response = self.serial_command(cmd, retries=15)
         return response
 
     def reverse(self):
+        self.__ensure_port_open()
         cmd = "GR"
         response = self.serial_command(cmd, retries=15)
         return response
 
     def stop(self):
+        self.__ensure_port_open()
         cmd = "G0"
         response = self.serial_command(cmd)
         return response
 
     def set_step(self, value):
+        self.__ensure_port_open()
         cmd = "S" + str(value)
         response = self.serial_command(cmd)
         return response
 
     def get_step(self):
+        self.__ensure_port_open()
         cmd = "S?"
         response = self.serial_command(cmd)
         step = response.split("Done")[0].split(":")[1]
         return int(step)
 
     def write_to_flash(self):
+        self.__ensure_port_open()
         cmd = "OW"
         response = self.serial_command(cmd)
         return response
 
     def start_burn_in(self, parameter):
+        self.__ensure_port_open()
         cmd = "OZBI" + str(parameter)
         response = self.serial_command(cmd)
         return response
 
     def write_name(self, parameter):
+        self.__ensure_port_open()
         cmd = "ODN" + str(parameter)
         response = self.serial_command(cmd)
         return response
 
     def write_serial(self, parameter):
+        self.__ensure_port_open()
         cmd = "ODS" + str(parameter)
         response = self.serial_command(cmd)
         return response
 
     def write_mfg_date(self, parameter):
+        self.__ensure_port_open()
         cmd = "ODM" + str(parameter)
         response = self.serial_command(cmd)
         return response
 
     def write_hw_version(self, parameter):
+        self.__ensure_port_open()
         cmd = "OHW" + str(parameter)
         response = self.serial_command(cmd)
         return response
 
     def serial_close(self):
+        self.__ensure_port_open()
         self.conn.close()
 
     def serial_send(self, serial_cmd):
@@ -171,11 +217,13 @@ class OdlOzOptics(OpticalDelayLine):
         return device_output
 
     def serial_command(self, serial_cmd, retries=5):
+        self.__ensure_port_open()
         self.serial_send(serial_cmd + self.command_terminate)
         device_output = self.serial_read(retries)
         return device_output
 
     def readKey(self, key, retries=5):
+        self.__ensure_port_open()
         device_output = ""
         got_OK = False
         while self.conn.in_waiting > 0 or (got_OK is False and retries > 0):
@@ -188,6 +236,7 @@ class OdlOzOptics(OpticalDelayLine):
         return device_output
 
     def readall(self, sectimeout=5):
+        self.__ensure_port_open()
         ok = False
         bytes = self.conn.read(1)
         while self.conn.inWaiting() > 0:

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -72,40 +72,44 @@ class OdlOzOptics(OpticalDelayLine):
                 raise DeviceDisconnectedError(f"{self} is disconnected")
 
     def move(self, dist: float):
-        self.logger.debug(f"ODL({self}): move command is received")
+        self.logger.debug(f"ODL({self}): move({dist}) command has been received")
         self.__ensure_port_open()
 
         if dist > self.max_move or dist < self.min_move:
             raise OdlMoveOutofRangeError(f"ODL({self}): Invalid Move Parameter:{dist}")
         else:
-            response = self.set_step(int(dist * self.resolution))
-            self.logger.debug(f"ODL({self}): move command complete: {response} verifying:")
+            cmd = "S" + str(int(dist * self.resolution))
+            response = self.serial_command(cmd)
+
+            #response = self.set_step(int(dist * self.resolution))
+            self.logger.debug(f"move command complete: {response} verifying:")
             step_position = self.get_step()
-            self.logger.debug(f"ODL({self}): final position after move:{step_position/self.resolution}")
+            self.logger.debug(f"final position after move:{step_position/self.resolution}")
 
     def set_step(self, value):
-        self.logger.debug(f"ODL({self}): set_step command is received")
+        self.logger.debug(f"ODL({self}): set_step command has been received")
         self.__ensure_port_open()
         cmd = "S" + str(value)
         response = self.serial_command(cmd)
+        self.logger.debug(f"set_step result: {response}")
+
         return response
 
     def get_step(self):
-        self.logger.debug(f"ODL({self}): get_step command is received")
+        self.logger.debug(f"ODL({self}): get_step has been started")
         self.__ensure_port_open()
         cmd = "S?"
         response = self.serial_command(cmd)
-        if (response.find("UNKNOWN")):
+        if (response.find("UNKNOWN") >= 0):
             raise OdlGetPosNotCompleted(
-                f"Unknown position for {self}: run find_home()
-                first and then change or get the position"
+                f"Unknown position for ODL({self}): run find_home() first and then change or get the position"
             )
         step = response.split("Done")[0].split(":")[1]
-        self.logger.debug(f"ODL({self}): get_step:{step}:return{int(step)}")
+        self.logger.debug(f"ODL({self}): get_step:{step}:{int(step)}")
         return int(step)
 
     def current_status(self):
-        self.logger.debug(f"ODL({self}): current_status query is received!")
+        self.logger.debug(f"ODL({self}): current_status query has been received!")
         self.__ensure_port_open()
         cmd = "Q?"
         response = self.serial_command(cmd)
@@ -113,21 +117,21 @@ class OdlOzOptics(OpticalDelayLine):
         return response
 
     def find_home(self):
-        self.logger.debug(f"ODL({self}): find_home command is received!")
+        self.logger.debug(f"ODL({self}): find_home command has been received!")
         self.__ensure_port_open()
         cmd = "FH"
         response = self.serial_command(cmd, retries=1000)
         return response
 
     def get_serial(self):
-        self.logger.debug(f"ODL({self}): get_serial command is received!")
+        self.logger.debug(f"ODL({self}): get_serial command has been received!")
         self.__ensure_port_open()
         cmd = "V2"
         response = self.serial_command(cmd)
         return response.split("Done")[0].split("\r\n")[1]
 
     def get_device_info(self):
-        self.logger.debug(f"ODL({self}): device_info command is received!")
+        self.logger.debug(f"ODL({self}): device_info command has been received!")
         self.__ensure_port_open()
         cmd = "V1"
         response = self.serial_command(cmd)
@@ -137,7 +141,7 @@ class OdlOzOptics(OpticalDelayLine):
         return device_name, hwd_version
 
     def get_mfg_date(self):
-        self.logger.debug(f"ODL({self}): get manufacturing date command (get_mfg_dates) is received!")
+        self.logger.debug(f"ODL({self}): get manufacturing date command (get_mfg_dates) has been received!")
         self.__ensure_port_open()
         cmd = "d?"
         response = self.serial_command(cmd)
@@ -145,7 +149,7 @@ class OdlOzOptics(OpticalDelayLine):
         return date
 
     def echo(self, on_off):
-        self.logger.debug(f"ODL({self}): echo({on_off}) command is received!")
+        self.logger.debug(f"ODL({self}): echo({on_off}) command has been received!")
 
         self.__ensure_port_open()
         cmd = "e" + str(on_off)
@@ -153,7 +157,7 @@ class OdlOzOptics(OpticalDelayLine):
         return response
 
     def reset(self):
-        self.logger.debug(f"ODL({self}): reset command is received!")
+        self.logger.debug(f"ODL({self}): reset command has been received!")
         self.__ensure_port_open()
         cmd = "RESET"
         response = self.serial_command(cmd)
@@ -167,14 +171,14 @@ class OdlOzOptics(OpticalDelayLine):
         return response
 
     def home(self):
-        self.logger.debug(f"ODL({self}): home command is received!")
+        self.logger.debug(f"ODL({self}): home command has been received!")
         self.__ensure_port_open()
         cmd = "GR"
         response = self.serial_command(cmd, retries=15)
         return response
 
     def end(self):
-        self.logger.debug(f"ODL({self}): end command is received!")
+        self.logger.debug(f"ODL({self}): end command has been received!")
 
         self.__ensure_port_open()
         cmd = "GF"
@@ -182,7 +186,7 @@ class OdlOzOptics(OpticalDelayLine):
         return response
 
     def stop(self):
-        self.logger.debug(f"ODL({self}): stop motor driver command is received!")
+        self.logger.debug(f"ODL({self}): stop motor driver command has been received!")
 
         self.__ensure_port_open()
         cmd = "G0"

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -36,7 +36,6 @@ class OdlOzOptics(OpticalDelayLine):
         serial_port: str | None = None,
         serial_number: str | None = None,
         config_file=None,
-        max_move = int | None = None,
     ):
         super().__init__(serial_port, serial_number, config_file)
         self.name = "OzOptics ODL"


### PR DESCRIPTION
- Rewrite the main method to fix the bugs reported in #34 and #35. 
- Adding basic logging capability for debugging. 
- Logical bug fix found in for home() command (the previous command was find_home not home())
- Replace  more appropriate name for home() and end() methods (instead of forward and reverse)
- Verify the position of the odl after moving