### PR TITLE
Fix bugs #34 #35 for unifying and error handling of get_step in OzOptics ODL 

### DIFF
--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -4,6 +4,7 @@
 import serial
 from serial import Serial
 from pnpq.devices.optical_delay_line import OpticalDelayLine
+from pnpq.errors import OdlGetPosNotCompleted
 import time
 
 

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -48,7 +48,7 @@ class OdlOzOptics(OpticalDelayLine):
         response = self.serial_command(cmd)
         return response
 
-    def get_step(self):
+    def get_step(self) -> int:
         response = self.serial_command(f"S?")
         if "UNKNOWN" in response:
             raise OdlGetPosNotCompleted(

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -116,12 +116,6 @@ class OdlOzOptics(OpticalDelayLine):
         response = self.serial_command(cmd)
         return response
 
-    def get_step(self):
-        cmd = "S?"
-        response = self.serial_command(cmd)
-        step = response.split("Done")[0].split(":")[1]
-        return int(step)
-
     def write_to_flash(self):
         cmd = "OW"
         response = self.serial_command(cmd)

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -49,7 +49,7 @@ class OdlOzOptics(OpticalDelayLine):
         return response
 
     def get_step(self) -> int:
-        response = self.serial_command(f"S?")
+        response = self.serial_command("S?")
         if "UNKNOWN" in response:
             raise OdlGetPosNotCompleted(
                 f"Unknown position for ODL({self}): run find_home() first and then change or get the position"

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -47,8 +47,14 @@ class OdlOzOptics(OpticalDelayLine):
         response = self.serial_command(cmd)
         return response
 
-    def current_step():
-        pass
+    def get_step(self):
+        response = self.serial_command(f"S?")
+        if "UNKNOWN" in response:
+            raise OdlGetPosNotCompleted(
+                f"Unknown position for ODL({self}): run find_home() first and then change or get the position"
+            )
+        step = response.split("Done")[0].split(":")[1]
+        return int(step)
 
     def home(self):
         cmd = "FH"


### PR DESCRIPTION
The bugs #34 and #35 are related. `current_step` is intended to perform the same functionality as `get_step`. Therefore, these two methods have been unified under `get_step`. Basic error handling for the UNKNOWN state has been implemented.  
