### PR TITLE
OdlOzOptics.set_step() is declared twice. They are the same. Deleted …

### DIFF
--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -112,11 +112,6 @@ class OdlOzOptics(OpticalDelayLine):
         response = self.serial_command(cmd)
         return response
 
-    def set_step(self, value):
-        cmd = "S" + str(value)
-        response = self.serial_command(cmd)
-        return response
-
     def write_to_flash(self):
         cmd = "OW"
         response = self.serial_command(cmd)


### PR DESCRIPTION
OdlOzOptics.set_step() is declared twice. They are the same.
The first one is from line 46.
The second one was from line 115.
Deleted the second one.