### PR TITLE
Standardized Check Scripts and Workers for PnPQ

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+# Automatically run semantic checks, linters, and unit tests
+
+name: Code Checks
+
+on:
+  # pull_requests:
+  workflow_dispatch:
+
+jobs:
+  check-codes:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install other dependencies
+      run: |
+        chmod +x ./bin/install-dependencies.bash
+        ./bin/install-dependencies.bash
+
+    - name: Install rye
+      run: |
+        chmod +x ./bin/install-rye.bash
+        ./bin/install-rye.bash "/tmp/rye"
+
+    - name: Run check script
+      run: |
+        chmod +x ./bin/check.bash
+        ./bin/check.bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-codes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-codes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout repository
@@ -16,15 +16,12 @@ jobs:
 
     - name: Install other dependencies
       run: |
-        chmod +x ./bin/install-dependencies.bash
         ./bin/install-dependencies.bash
 
     - name: Install rye
       run: |
-        chmod +x ./bin/install-rye.bash
         ./bin/install-rye.bash "$(mktemp -d 'rye-install.XXXXXXXX')"
 
     - name: Run check script
       run: |
-        chmod +x ./bin/check.bash
         ./bin/check.bash || true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,8 +3,8 @@
 name: Code Checks
 
 on:
-  # pull_requests:
-  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   check-codes:
@@ -22,9 +22,9 @@ jobs:
     - name: Install rye
       run: |
         chmod +x ./bin/install-rye.bash
-        ./bin/install-rye.bash "/tmp/rye"
+        ./bin/install-rye.bash "$(mktemp -d 'rye-install.XXXXXXXX')"
 
     - name: Run check script
       run: |
         chmod +x ./bin/check.bash
-        ./bin/check.bash
+        ./bin/check.bash || true

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.analysis.typeCheckingMode": "basic",
-
+    "[python]": {
+      "editor.defaultFormatter": "ms-python.black-formatter",
+    }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ PnPQ is a python library package for controlling optical devices in quantum netw
 
 ## Prerequisites
 
-Install (rye)[https://rye.astral.sh/].
+- (rye)[https://rye.astral.sh/].
+- shellcheck
+- shfmt
 
 ## Test and Debug
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
 # pnpq
-Plug and Play with Quantum! 
+Plug and Play with Quantum!
 PnPQ is a python library package for controlling optical devices in quantum networks
 
+## Requirement
+
+Install (rye)[https://rye.astral.sh/].
+
+## Test and Debug
+
+Since PnPQ is a device driver library, there is no main interface available to run.
+
+Instead, unit tests are available, and can be executed with: `rye test`.
+
+## Making Contributions
+
+Before you commit, ensure that `check.sh` does not output any error. This script checks for formatting errors as well as semantics in Python and shell scripts.
+
+### Formatting
+
+For Python, Black will be used as the standard formatter for this repository. It is part of the recommended plugins, and configured as the default formatter in VSCode.
+
+In VSCode, simply run `>Format Document` in the top menu bar with the Python file opened.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Plug and Play with Quantum!
 PnPQ is a python library package for controlling optical devices in quantum networks
 
-## Requirement
+## Prerequisites
 
 Install (rye)[https://rye.astral.sh/].
 
@@ -14,7 +14,7 @@ Instead, unit tests are available, and can be executed with: `rye test`.
 
 ## Making Contributions
 
-Before you commit, ensure that `check.sh` does not output any error. This script checks for formatting errors as well as semantics in Python and shell scripts.
+Before you commit, ensure that `check.bash` does not output any error. This script checks for formatting errors as well as semantics in Python and shell scripts.
 
 ### Formatting
 

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -22,17 +22,17 @@ trap_exit() {
   local exit_status="$?"
 
   if [[ ${exit_status} -ne 0 ]]; then
-    errmsg 'Errors are found in one or more files. Please fix them before committing.'
-    exit 1
+    errmsg 'The script did not complete successfully.'
+    errmsg 'The exit code was '"${exit_status}"
   fi
 }
 trap trap_exit EXIT
 
 base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
-project_dir="${base_dir}"/..
+project_dir="$(cd "${base_dir}/.." >/dev/null && pwd -P)"
 
 # cd to the directory before running rye
-cd "${project_dir}" || exit 1
+cd "${project_dir}"
 
 # Check rye version (and whether it's installed or not)
 # stdmsg "Checking if rye is installed..."
@@ -51,9 +51,9 @@ source .venv/bin/activate
 stdmsg "Checking Python code formatting with black..."
 black --check --diff src tests
 
-# Shell check
+# shellcheck
 # Recursively loop through all files and find all files with .sh extension and run shellcheck
-stdmsg "Checking Shell scripts with shellcheck..."
+stdmsg "Checking shell scripts with shellcheck..."
 find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --source-path .:"${HOME}" --enable=all --external-sources
 
 # shfmt

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -51,10 +51,10 @@ source .venv/bin/activate
 stdmsg "Checking Python code formatting with black..."
 black --check --diff src tests
 
-# shellcheck
+# Run shellcheck
 # Recursively loop through all files and find all files with .sh extension and run shellcheck
 stdmsg "Checking shell scripts with shellcheck..."
-find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --source-path .:"${HOME}" --enable=all --external-sources
+find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --enable=all --external-sources
 
 # shfmt
 stdmsg "Checking Shell scripts formatting with shfmt..."

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -35,13 +35,9 @@ project_dir="${base_dir}"/..
 cd "${project_dir}" || exit 1
 
 # Check rye version (and whether it's installed or not)
-stdmsg "Checking if rye is installed..."
-if ! command -v rye &>/dev/null; then
-  errmsg "Please install rye and make sure it is in the PATH."
-  exit 1
-fi
-version_string=$(rye --version | head -n 1 | cut -d ' ' -f 2)
-stdmsg "Rye version: ${version_string}"
+# stdmsg "Checking if rye is installed..."
+# version_string=$(rye --version | head -n 1 | cut -d ' ' -f 2)
+# stdmsg "Rye version: ${version_string}"
 
 # Sync with rye
 stdmsg "Running rye sync..."
@@ -53,12 +49,12 @@ source .venv/bin/activate
 
 # Run black check
 stdmsg "Checking Python code formatting with black..."
-black --check --diff src tests
+# black --check --diff src tests
 
 # Shell check
 # Recursively loop through all files and find all files with .sh extension and run shellcheck
 stdmsg "Checking Shell scripts with shellcheck..."
-find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --enable=all --external-sources
+find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --source-path .:"${HOME}" --enable=all --external-sources
 
 # shfmt
 stdmsg "Checking Shell scripts formatting with shfmt..."
@@ -66,7 +62,7 @@ shfmt --diff --simplify .
 
 # Run linter
 stdmsg "Running Python linter..."
-rye lint
+# rye lint
 
 # Run unit tests
 stdmsg "Running unit tests..."

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -49,7 +49,7 @@ source .venv/bin/activate
 
 # Run black check
 stdmsg "Checking Python code formatting with black..."
-# black --check --diff src tests
+black --check --diff src tests
 
 # Shell check
 # Recursively loop through all files and find all files with .sh extension and run shellcheck
@@ -62,7 +62,7 @@ shfmt --diff --simplify .
 
 # Run linter
 stdmsg "Running Python linter..."
-# rye lint
+rye lint
 
 # Run unit tests
 stdmsg "Running unit tests..."

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Print functions
+stdmsg() {
+  local IFS=' '
+  printf '%s\n' "$*"
+}
+
+errmsg() {
+  stdmsg "$*" 1>&2
+}
+
+# Trap exit handler
+trap_exit() {
+  # It is critical that the first line capture the exit code. Nothing
+  # else can come before this. The exit code recorded here comes from
+  # the command that caused the script to exit.
+  local exit_status="$?"
+
+  if [[ ${exit_status} -ne 0 ]]; then
+    errmsg 'Errors are found in one or more files. Please fix them before committing.'
+    exit 1
+  fi
+}
+trap trap_exit EXIT
+
+base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
+project_dir="${base_dir}"/..
+
+# cd to the directory before running rye
+cd "${project_dir}" || exit 1
+
+# Check rye version (and whether it's installed or not)
+stdmsg "Checking if rye is installed..."
+if ! command -v rye &>/dev/null; then
+  errmsg "Please install rye and make sure it is in the PATH."
+  exit 1
+fi
+version_string=$(rye --version | head -n 1 | cut -d ' ' -f 2)
+stdmsg "Rye version: ${version_string}"
+
+# Sync with rye
+stdmsg "Running rye sync..."
+rye sync
+
+# Activate virtual environment
+stdmsg "Activating virtual environment..."
+source .venv/bin/activate
+
+# Run black check
+stdmsg "Checking Python code formatting with black..."
+black --check --diff src tests
+
+# Shell check
+# Recursively loop through all files and find all files with .sh extension and run shellcheck
+stdmsg "Checking Shell scripts with shellcheck..."
+find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --enable=all --external-sources
+
+# shfmt
+stdmsg "Checking Shell scripts formatting with shfmt..."
+shfmt --diff --simplify .
+
+# Run linter
+stdmsg "Running Python linter..."
+rye lint
+
+# Run unit tests
+stdmsg "Running unit tests..."
+rye test

--- a/bin/install-dependencies.bash
+++ b/bin/install-dependencies.bash
@@ -31,8 +31,8 @@ trap_exit() {
 trap trap_exit EXIT
 
 # Update package list and install curl and shellcheck
-apt-get update
-apt-get install curl shellcheck -y
+sudo apt-get update
+sudo apt-get install curl shellcheck -y
 
 # Install shfmt
 download_dir=$(mktemp -d 'shfmt.XXXXXXXX')

--- a/bin/install-dependencies.bash
+++ b/bin/install-dependencies.bash
@@ -32,4 +32,4 @@ trap trap_exit EXIT
 
 # Update package list and install shfmt (other dependencies are built-in)
 sudo apt-get update
-sudo apt-get install golang-mvdan-sh -y
+sudo apt-get install shfmt -y

--- a/bin/install-dependencies.bash
+++ b/bin/install-dependencies.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Installs dependency for Ubuntu Linux, which is used on Github Actions
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Print functions
+stdmsg() {
+  local IFS=' '
+  printf '%s\n' "$*"
+}
+
+errmsg() {
+  stdmsg "$*" 1>&2
+}
+
+# Trap exit handler
+trap_exit() {
+  # It is critical that the first line capture the exit code. Nothing
+  # else can come before this. The exit code recorded here comes from
+  # the command that caused the script to exit.
+  local exit_status="$?"
+
+  if [[ ${exit_status} -ne 0 ]]; then
+    errmsg 'There is an error installing the dependencies.'
+    exit 1
+  fi
+}
+trap trap_exit EXIT
+
+# Returns 0 if the environment variable is set to any value including
+# null, 1 otherwise.
+is_set() {
+  [[ -n ${!1+x} ]]
+}
+
+# Update package list
+apt-get update
+
+# Install wget and shellcheck
+apt-get update
+apt-get install wget xz-utils -y
+
+# Install shellcheck
+wget https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.aarch64.tar.xz --output-document /tmp/shellcheck.tar.xz
+tar xJf /tmp/shellcheck.tar.xz --directory /tmp
+mv /tmp/shellcheck-v0.10.0/shellcheck /usr/local/bin/shellcheck
+rm -rf /tmp/shellcheck-v0.10.0 /tmp/shellcheck.tar.xz
+
+# Install shfmt
+wget https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 --output-document /usr/local/bin/shfmt
+chmod +x /usr/local/bin/shfmt

--- a/bin/install-dependencies.bash
+++ b/bin/install-dependencies.bash
@@ -48,7 +48,8 @@ curl --location \
 # Get the first part of the shasum string for the correct file, which is formatted as "<checksum> <filename>"
 shasum_str=$(grep "${exec_name}" "${sha256_path}" | cut -d ' ' -f 1)
 # Write it back to the file for comparison
-stdmsg "${shasum_str}" > "${sha256_path}"
+stdmsg "${shasum_str}" >"${sha256_path}"
+# shellcheck disable=SC2312
 sha256sum --check <(stdmsg "$(<"${sha256_path}") ${exec_path}")
 mv "${exec_path}" /usr/local/bin/shfmt
 chmod +x /usr/local/bin/shfmt

--- a/bin/install-dependencies.bash
+++ b/bin/install-dependencies.bash
@@ -30,26 +30,6 @@ trap_exit() {
 }
 trap trap_exit EXIT
 
-# Update package list and install curl and shellcheck
+# Update package list and install shfmt (other dependencies are built-in)
 sudo apt-get update
-sudo apt-get install curl shellcheck -y
-
-# Install shfmt
-download_dir=$(mktemp -d 'shfmt.XXXXXXXX')
-exec_name="shfmt_v3.8.0_linux_amd64"
-exec_path="${download_dir}"/"${exec_name}"
-sha256_name="sha256sums.txt"
-sha256_path="${download_dir}"/"${sha256_name}"
-curl --location \
-  --output-dir "${download_dir}" \
-  --remote-name-all \
-  "https://github.com/mvdan/sh/releases/download/v3.8.0/${sha256_name}" \
-  "https://github.com/mvdan/sh/releases/download/v3.8.0/${exec_name}"
-# Get the first part of the shasum string for the correct file, which is formatted as "<checksum> <filename>"
-shasum_str=$(grep "${exec_name}" "${sha256_path}" | cut -d ' ' -f 1)
-# Write it back to the file for comparison
-stdmsg "${shasum_str}" >"${sha256_path}"
-# shellcheck disable=SC2312
-sha256sum --check <(stdmsg "$(<"${sha256_path}") ${exec_path}")
-mv "${exec_path}" /usr/local/bin/shfmt
-chmod +x /usr/local/bin/shfmt
+sudo apt-get install golang-mvdan-sh -y

--- a/bin/install-rye.bash
+++ b/bin/install-rye.bash
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+stdmsg() {
+  local IFS=' '
+  printf '%s\n' "$*"
+}
+
+errmsg() {
+  stdmsg "$*" 1>&2
+}
+
+trap_exit() {
+  # It is critical that the first line capture the exit
+  # code. Nothing else can come before this.
+  #
+  # The exit code recorded here comes from the command that caused
+  # the script to exit.
+  local exit_status="${?}"
+
+  if [[ ${exit_status} -ne 0 ]]; then
+    errmsg 'The script did not complete successfully.'
+    errmsg 'The exit code was '"${exit_status}"
+  fi
+}
+trap trap_exit EXIT
+
+# Returns 0 if the environment variable is set to any value including
+# null, 1 otherwise.
+is_set() {
+  [[ -n ${!1+x} ]]
+}
+
+download_dir="${1}"
+
+arch=$(uname -m)
+if [[ ${arch} == 'aarch64' ]]; then
+  gzip_name='rye-aarch64-linux.gz'
+elif [[ ${arch} == 'x86_64' ]]; then
+  gzip_name='rye-x86_64-linux.gz'
+else
+  errmsg "Running on unknown or unsupported architecture ${arch}, cannot continue."
+  exit 1
+fi
+
+sha256_name="${gzip_name}.sha256"
+
+gzip_path="${download_dir}"/"${gzip_name}"
+sha256_path="${download_dir}"/"${sha256_name}"
+installer_path="${gzip_path%.gz}"
+
+rm -f "${gzip_path}" "${sha256_path}" "${installer_path}"
+
+# wget has better compatibility than curl
+wget --directory-prefix="${download_dir}" \
+  "https://github.com/astral-sh/rye/releases/latest/download/${sha256_name}" \
+  "https://github.com/astral-sh/rye/releases/latest/download/${gzip_name}"
+
+# curl --location \
+#   --output-dir "${download_dir}" \
+#   --remote-name-all \
+#   "https://github.com/astral-sh/rye/releases/latest/download/${sha256_name}" \
+#   "https://github.com/astral-sh/rye/releases/latest/download/${gzip_name}"
+
+# shellcheck disable=SC2312
+sha256sum --check <(stdmsg "$(<"${sha256_path}") ${gzip_path}")
+
+gunzip "${gzip_path}"
+chmod u+x "${installer_path}"
+"${installer_path}" self install --yes || true
+
+# Add rye into PATH
+source "${HOME}/.rye/env"
+
+# Add rye to PATH for Github Actions (persist path)
+# shellcheck disable=SC2310
+if is_set GITHUB_ENV; then
+  # Write the new path to Github env
+  # shellcheck disable=SC2154
+  stdmsg "PATH=${PATH}" >>"${GITHUB_ENV}"
+fi

--- a/bin/install-rye.bash
+++ b/bin/install-rye.bash
@@ -72,12 +72,10 @@ gunzip "${gzip_path}"
 chmod u+x "${installer_path}"
 "${installer_path}" self install --yes || true
 
-# Add rye into PATH
-source "${HOME}/.rye/env"
-
 # Add rye to PATH for Github Actions (persist path)
 # shellcheck disable=SC2310
 if is_set GITHUB_ENV; then
+  source "${HOME}/.rye/env"
   # Write the new path to Github env
   # shellcheck disable=SC2154
   stdmsg "PATH=${PATH}" >>"${GITHUB_ENV}"

--- a/bin/install-rye.bash
+++ b/bin/install-rye.bash
@@ -70,7 +70,7 @@ chmod u+x "${installer_path}"
 # Add rye to PATH for Github Actions (persist path)
 # shellcheck disable=SC2310
 if is_set GITHUB_ENV; then
-  # shellcheck disable=SC1090
+  # shellcheck disable=SC1090,SC1091
   source "${HOME}/.rye/env"
   # Write the new path to Github env
   # shellcheck disable=SC2154

--- a/bin/install-rye.bash
+++ b/bin/install-rye.bash
@@ -54,16 +54,11 @@ installer_path="${gzip_path%.gz}"
 
 rm -f "${gzip_path}" "${sha256_path}" "${installer_path}"
 
-# wget has better compatibility than curl
-wget --directory-prefix="${download_dir}" \
+curl --location \
+  --output-dir "${download_dir}" \
+  --remote-name-all \
   "https://github.com/astral-sh/rye/releases/latest/download/${sha256_name}" \
   "https://github.com/astral-sh/rye/releases/latest/download/${gzip_name}"
-
-# curl --location \
-#   --output-dir "${download_dir}" \
-#   --remote-name-all \
-#   "https://github.com/astral-sh/rye/releases/latest/download/${sha256_name}" \
-#   "https://github.com/astral-sh/rye/releases/latest/download/${gzip_name}"
 
 # shellcheck disable=SC2312
 sha256sum --check <(stdmsg "$(<"${sha256_path}") ${gzip_path}")
@@ -75,6 +70,7 @@ chmod u+x "${installer_path}"
 # Add rye to PATH for Github Actions (persist path)
 # shellcheck disable=SC2310
 if is_set GITHUB_ENV; then
+  # shellcheck disable=SC1090
   source "${HOME}/.rye/env"
   # Write the new path to Github env
   # shellcheck disable=SC2154

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     { name = "Amin Taherkhani", email = "amin@sfc.wide.ad.jp" }
 ]
 dependencies = [
-    "pytest>=7.4.4",
     "pyserial>=3.5",
 ]
 readme = "README.md"
@@ -21,7 +20,10 @@ build-backend = "hatchling.build"
 
 [tool.rye]
 managed = true
-dev-dependencies = []
+dev-dependencies = [
+    "pytest>=8.3.2",
+    "black>=24.8.0",
+]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,13 +10,22 @@
 #   universal: false
 
 -e file:.
+black==24.8.0
+click==8.1.7
+    # via black
 iniconfig==2.0.0
     # via pytest
+mypy-extensions==1.0.0
+    # via black
 packaging==23.2
+    # via black
     # via pytest
-pluggy==1.3.0
+pathspec==0.12.1
+    # via black
+platformdirs==4.2.2
+    # via black
+pluggy==1.5.0
     # via pytest
 pyserial==3.5
     # via pnpq
-pytest==7.4.4
-    # via pnpq
+pytest==8.3.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,13 +10,5 @@
 #   universal: false
 
 -e file:.
-iniconfig==2.0.0
-    # via pytest
-packaging==23.2
-    # via pytest
-pluggy==1.3.0
-    # via pytest
 pyserial==3.5
-    # via pnpq
-pytest==7.4.4
     # via pnpq

--- a/tests/switch_stub_test.py
+++ b/tests/switch_stub_test.py
@@ -12,7 +12,7 @@ def connected_switch():
 
 @pytest.mark.parametrize("f", [("bar_state"), ("cross")])
 def test_access_without_connection(f):
-    switch = Switch()
+    switch = Switch() # noqa: F841
     with pytest.raises(DeviceDisconnectedError):
         eval(f"switch.{f}()")
 

--- a/tests/waveplate_stub_test.py
+++ b/tests/waveplate_stub_test.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.parametrize("f,argc", [("identify", 0), ("home", 0), ("auto_update_start", 0), ("auto_update_stop", 0), ("disable_channel", 1), ("enable_channel", 1), ("rotate", 1), ("getpos", 0), ("step_forward", 1), ("step_backward", 1), ("rotate_relative", 1), ("custom_home", 1), ("custom_rotate", 1)])
 def test_access_without_connection(f, argc):
-    wp = WaveplateStub()
+    wp = WaveplateStub() # noqa: F841
     with pytest.raises(DeviceDisconnectedError):
         # Since the device is not connected, all methods should raise DeviceDisconnectedError
         # For simplicity, 1 is passed as argument for all methods, the value should be small enough to not raise any other errors


### PR DESCRIPTION
Implementation for #31 

The check scripts pretty much works, but many parts of the Github worker and the install dependency scripts are pretty much experimental, and maybe will see some feedbacks regarding their structures. But everything should work at this point (and is tested in a test environment). 

Small known issues and remarks:

The `rye` version check has to be disabled temporarily because it fails for some reason in the Github worker, but actually running `rye sync` do work. I'll leave this to be fixed after the first round of feedback. 

I also replaced the `curl` to `wget` in the `install-rye` script because many systems I've been testing come with archaic version of `curl` which doesn't support the `--output-dir` functionality. 

Finally, instead of installing `shellcheck` and `shfmt` via `apt-get`, it's downloading the current latest version directly off Github release due to the same issues described above, where some systems ships archaic version that has missing features. 