### PR TITLE
Fix static analysis errors and enable PR checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,4 +24,4 @@ jobs:
 
     - name: Run check script
       run: |
-        ./bin/check.bash || true
+        ./bin/check.bash

--- a/example.py
+++ b/example.py
@@ -1,8 +1,5 @@
-from pnpq import Waveplate
-from pnpq import Switch
 from pnpq import OdlThorlabs
 from pnpq import OdlOzOptics
-from pnpq.devices.optical_delay_line import OpticalDelayLine
 
 print("hello world")
 # wp = Waveplate(serial_number='00AAABBB')

--- a/src/pnpq/__init__.py
+++ b/src/pnpq/__init__.py
@@ -1,10 +1,6 @@
-#
-#  Copyright (C) 2024 Moontshot Nagayama Project
-#
-
 "Python interface for Controlling Optical Devices in Quantum Networks"
 __version__ = "0.0.1"
-from .devices import *
+from .devices import OpticalDelayLine, Switch, Waveplate
 
 __all__ = ["Waveplate", "Switch", "OpticalDelayLine"]
 

--- a/src/pnpq/devices/__init__.py
+++ b/src/pnpq/devices/__init__.py
@@ -1,5 +1,15 @@
-from .waveplate_thorlabs_kb10crm import Waveplate
-from .switch_thorlabs_osw1310E import Switch
-from .odl_thorlabs_kbd101 import OdlThorlabs
 from .odl_ozoptics_650ml import OdlOzOptics
+from .odl_thorlabs_kbd101 import OdlThorlabs
+from .optical_delay_line import OpticalDelayLine
+from .switch_thorlabs_osw1310E import Switch
 from .waveplate_stub import WaveplateStub
+from .waveplate_thorlabs_kb10crm import Waveplate
+
+__all__ = [
+    "OdlOzOptics",
+    "OdlThorlabs",
+    "OpticalDelayLine",
+    "Switch",
+    "Waveplate",
+    "WaveplateStub",
+]

--- a/src/pnpq/devices/odl_ozoptics_650ml.py
+++ b/src/pnpq/devices/odl_ozoptics_650ml.py
@@ -1,8 +1,5 @@
-#
 # OzOptics ODL module driver
-#
-import serial
-from serial import Serial
+
 from pnpq.devices.optical_delay_line import OpticalDelayLine
 from pnpq.errors import OdlGetPosNotCompleted
 import time
@@ -23,10 +20,7 @@ class OdlOzOptics(OpticalDelayLine):
 
         self.command_terminate = "\r\n"
 
-        try:
-            self.conn.open()
-        except:
-            raise RuntimeError("Can not open OZ optic ODL device")
+        self.conn.open()
 
     def connect(self):
         if self.conn.is_open == 0:

--- a/src/pnpq/devices/odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/odl_thorlabs_kbd101.py
@@ -3,13 +3,11 @@
 #       Brushless Motor Driver: KBD101
 #       Stage:                  DDS100/M
 #
-import serial
-import time, logging
-from serial import Serial
+import logging
+import time
 from pnpq.devices.optical_delay_line import OpticalDelayLine
 
 from pnpq.errors import (
-    DevicePortNotFoundError,
     DeviceDisconnectedError,
     OdlMoveNotCompleted,
     OdlHomeNotCompleted,
@@ -101,7 +99,7 @@ class OdlThorlabs(OpticalDelayLine):
         self.conn.open()
 
         if not self.conn.is_open:
-            raise DeviceDisconnectedError(f"ODL device is disconneced")
+            raise DeviceDisconnectedError("ODL device is disconneced")
         self.logger.info(f"({self}): Connecting to Thorlabs ODL module")
         # Enable Channel ID (0)
         self.conn.write(ENABLE_CHANNEL_SET_COMMAND)
@@ -109,7 +107,7 @@ class OdlThorlabs(OpticalDelayLine):
         self.conn.write(ENABLE_CHANNEL_GET_COMMAND)
         enable_channel_result = self.__wait_for_reply(b"\x12\x02", 5)
         if enable_channel_result is None:
-            self.logger.error(f"can not enable odl channel")
+            self.logger.error("cannot enable odl channel")
 
     def identify(self) -> None:
         self.__ensure_port_open()
@@ -145,7 +143,7 @@ class OdlThorlabs(OpticalDelayLine):
 
         move_result = self.__wait_for_reply(b"\x64\04", self.move_timeout)
         if not move_result:
-            self.logger.error(f"move command is not completed")
+            self.logger.error("move command is not completed")
             # raise OdlMoveNotCompleted(
             #    f"ODL({self}): No moved_completed response has been received"
             # )
@@ -164,7 +162,7 @@ class OdlThorlabs(OpticalDelayLine):
         forward_result = self.__wait_for_reply(b"\x64\x04", self.move_timeout)
 
         if not forward_result:
-            self.logger.error(f"step forward command is not completed")
+            self.logger.error("step forward command is not completed")
             raise OdlMoveNotCompleted(
                 f"ODL({self}: No response is received for step_forward command)"
             )
@@ -198,7 +196,7 @@ class OdlThorlabs(OpticalDelayLine):
 
         backward_result = self.__wait_for_reply(b"\x64\x04", self.move_timeout)
         if not backward_result:
-            self.logger.error(f"step backward command is not completed")
+            self.logger.error("step backward command is not completed")
             raise OdlMoveNotCompleted(
                 f"ODL{self}: No response is received for step_backward command"
             )

--- a/src/pnpq/devices/optical_delay_line.py
+++ b/src/pnpq/devices/optical_delay_line.py
@@ -1,6 +1,4 @@
 import serial
-import time
-from serial.tools import list_ports
 from serial import Serial
 
 

--- a/src/pnpq/devices/switch_stub.py
+++ b/src/pnpq/devices/switch_stub.py
@@ -1,8 +1,7 @@
 import logging
 
-from pnpq.errors import (
-    DeviceDisconnectedError,
-)
+from pnpq.errors import DeviceDisconnectedError
+
 
 class Switch:
     """Stub Switch Device Class"""

--- a/src/pnpq/devices/switch_thorlabs_osw1310E.py
+++ b/src/pnpq/devices/switch_thorlabs_osw1310E.py
@@ -4,7 +4,6 @@
 #
 import serial
 from serial import Serial
-from serial.tools import list_ports
 
 
 class Switch:
@@ -30,8 +29,8 @@ class Switch:
                     self.conn.port = ports.device
                     find_Port = True
                     break
-            if find_Port == False:
-                raise Exception("Can not find Switch by serial_number (FTDI_SN)")
+            if not find_Port:
+                raise Exception("Cannot find Switch by serial_number (FTDI_SN)")
 
         # if config_file != 0:
         #    if find_Port:

--- a/src/pnpq/devices/utils.py
+++ b/src/pnpq/devices/utils.py
@@ -21,7 +21,7 @@ def get_available_port(device_serial_number: str) -> str | None:
 
 
 def check_usb_hub_connected() -> bool:
-    logger.debug(f"check_usb_hub_connected")
+    logger.debug("check_usb_hub_connected")
     available_ports = list_comports()
     for port in available_ports:
         pair_tuple = (port.vid, port.pid)

--- a/src/pnpq/devices/waveplate_stub.py
+++ b/src/pnpq/devices/waveplate_stub.py
@@ -2,15 +2,10 @@ import logging
 import time
 
 from pnpq.errors import (
-    DevicePortNotFoundError,
     DeviceDisconnectedError,
-    WavePlateMoveNotCompleted,
-    WavePlateHomedNotCompleted,
-    WavePlateGetPosNotCompleted,
     WavePlateCustomRotateError,
     WaveplateInvalidStepsError,
     WaveplateInvalidDegreeError,
-    WaveplateEnableChannelError,
     WaveplateInvalidMotorChannelError,
 )
 

--- a/src/pnpq/devices/waveplate_stub.py
+++ b/src/pnpq/devices/waveplate_stub.py
@@ -14,6 +14,7 @@ from pnpq.errors import (
     WaveplateInvalidMotorChannelError,
 )
 
+
 class WaveplateStub:
     """Stub Waveplate Device Class"""
 
@@ -25,7 +26,7 @@ class WaveplateStub:
         # Resolution of the device in steps per degree
         self.resolution: int = 136533
         # Maximum steps the device can move (360 degrees)
-        self.max_steps: int = 136533*360
+        self.max_steps: int = 136533 * 360
         # Maximum channel the device can control
         self.max_channel: int = 1
         # Flag for auto updating device information
@@ -51,12 +52,16 @@ class WaveplateStub:
     def __ensure_valid_steps(self, steps: int) -> None:
         if 0 <= steps <= self.max_steps:
             return
-        raise WaveplateInvalidStepsError(f"Invalid steps: {steps}. Steps must be in a range [0,{self.max_steps}]")
+        raise WaveplateInvalidStepsError(
+            f"Invalid steps: {steps}. Steps must be in a range [0,{self.max_steps}]"
+        )
 
     def __ensure_valid_degree(self, degree: float) -> None:
         if 0 <= degree <= 360:
             return
-        raise WaveplateInvalidDegreeError(f"Invalid degree: {degree}. Degree must be in a range [0,360]")
+        raise WaveplateInvalidDegreeError(
+            f"Invalid degree: {degree}. Degree must be in a range [0,360]"
+        )
 
     def __stub_check_channel(self, chanid: int) -> bool:
         return chanid in self.enabled_channels
@@ -139,7 +144,11 @@ class WaveplateStub:
         """Get the current position of the device in steps"""
         self.__ensure_port_open()
         self.logger.info("Stub Waveplate Get Position")
-        self.logger.info("Current Position: Steps: %s Degrees: %s", self.current_position, self.current_position / self.resolution)
+        self.logger.info(
+            "Current Position: Steps: %s Degrees: %s",
+            self.current_position,
+            self.current_position / self.resolution,
+        )
         return self.current_position
 
     def get_degree(self) -> float:

--- a/src/pnpq/devices/waveplate_thorlabs_kb10crm.py
+++ b/src/pnpq/devices/waveplate_thorlabs_kb10crm.py
@@ -1,4 +1,5 @@
-import time, logging
+import logging
+import time
 from serial import Serial
 
 from pnpq.errors import (
@@ -108,7 +109,7 @@ class Waveplate:
 
             # the sequence is found
             if num_read_bytes > 0 and result.find(sequence) != -1:
-                self.logger.debug(f"The sequence found")
+                self.logger.debug("The sequence found")
                 return result
 
             time.sleep(1)
@@ -177,7 +178,7 @@ class Waveplate:
         self.__ensure_port_open()
 
         if chanid >= self.max_channel:
-            raise WavePlateInvalidMotorChannelError(
+            raise WaveplateInvalidMotorChannelError(
                 f"Invalid channel ID specified: {chanid}. it must be 0 in K10CR1/M"
             )
         msg = b"\x10\x02\x00\x02\x50\x01"
@@ -189,7 +190,7 @@ class Waveplate:
         self.__ensure_port_open()
 
         if chanid >= self.max_channel:
-            raise WavePlateInvalidMotorChannelError(
+            raise WaveplateInvalidMotorChannelError(
                 f"Invalid channel ID specified: {chanid}. It must be in 0 for K10CR1/M"
             )
 
@@ -233,7 +234,7 @@ class Waveplate:
         if result is None:
             self.logger.error("getpos command is not completed")
             raise WavePlateGetPosNotCompleted(
-                f"No update response has been received for determining the position"
+                "No update response has been received for determining the position"
             )
 
         else:

--- a/src/pnpq/devices/waveplate_thorlabs_kb10crm_test.py
+++ b/src/pnpq/devices/waveplate_thorlabs_kb10crm_test.py
@@ -1,6 +1,0 @@
-from .waveplate_thorlabs_kb10crm import Waveplate
-
-
-def test_init_waveplate():
-    wp = Waveplate()
-    # wp.identify()

--- a/src/pnpq/utils.py
+++ b/src/pnpq/utils.py
@@ -1,6 +1,5 @@
 from serial.tools.list_ports import comports as list_comports
 import logging
-import usb
 
 logger = logging.getLogger("utils")
 

--- a/tests/switch_stub_test.py
+++ b/tests/switch_stub_test.py
@@ -1,8 +1,7 @@
 from pnpq.devices.switch_stub import Switch
-from pnpq.errors import (
-    DeviceDisconnectedError
-)
+from pnpq.errors import DeviceDisconnectedError
 import pytest
+
 
 @pytest.fixture
 def connected_switch():
@@ -10,15 +9,18 @@ def connected_switch():
     switch.connect()
     return switch
 
+
 @pytest.mark.parametrize("f", [("bar_state"), ("cross")])
 def test_access_without_connection(f):
-    switch = Switch() # noqa: F841
+    switch = Switch()  # noqa: F841
     with pytest.raises(DeviceDisconnectedError):
         eval(f"switch.{f}()")
+
 
 def test_set_bar_state(connected_switch):
     connected_switch.bar_state()
     assert connected_switch.state == 1
+
 
 def test_set_cross_state(connected_switch):
     connected_switch.cross()

--- a/tests/waveplate_stub_test.py
+++ b/tests/waveplate_stub_test.py
@@ -7,9 +7,27 @@ from pnpq.errors import (
 )
 import pytest
 
-@pytest.mark.parametrize("f,argc", [("identify", 0), ("home", 0), ("auto_update_start", 0), ("auto_update_stop", 0), ("disable_channel", 1), ("enable_channel", 1), ("rotate", 1), ("getpos", 0), ("step_forward", 1), ("step_backward", 1), ("rotate_relative", 1), ("custom_home", 1), ("custom_rotate", 1)])
+
+@pytest.mark.parametrize(
+    "f,argc",
+    [
+        ("auto_update_start", 0),
+        ("auto_update_stop", 0),
+        ("custom_home", 1),
+        ("custom_rotate", 1),
+        ("disable_channel", 1),
+        ("enable_channel", 1),
+        ("getpos", 0),
+        ("home", 0),
+        ("identify", 0),
+        ("rotate", 1),
+        ("rotate_relative", 1),
+        ("step_backward", 1),
+        ("step_forward", 1),
+    ],
+)
 def test_access_without_connection(f, argc):
-    wp = WaveplateStub() # noqa: F841
+    wp = WaveplateStub()  # noqa: F841
     with pytest.raises(DeviceDisconnectedError):
         # Since the device is not connected, all methods should raise DeviceDisconnectedError
         # For simplicity, 1 is passed as argument for all methods, the value should be small enough to not raise any other errors
@@ -17,27 +35,33 @@ def test_access_without_connection(f, argc):
         arg = ",".join(["1"] * argc)
         eval(f"wp.{f}({arg})")
 
+
 @pytest.fixture
 def connected_waveplate():
     wp = WaveplateStub()
     wp.connect()
     return wp
 
+
 def test_identify(connected_waveplate):
     connected_waveplate.identify()
+
 
 def test_home(connected_waveplate):
     connected_waveplate.rotate(90)
     connected_waveplate.home()
     assert connected_waveplate.getpos() == 0
 
+
 def test_rotate(connected_waveplate):
     connected_waveplate.rotate(90)
     assert connected_waveplate.getpos() == 90 * connected_waveplate.resolution
 
+
 def test_rotate_invalid_degree(connected_waveplate):
     with pytest.raises(WaveplateInvalidDegreeError):
         connected_waveplate.rotate(361)
+
 
 def test_disable_and_enable_channels(connected_waveplate):
     connected_waveplate.disable_channel(1)
@@ -48,10 +72,12 @@ def test_disable_and_enable_channels(connected_waveplate):
     connected_waveplate.rotate(90)
     assert connected_waveplate.getpos() == 90 * connected_waveplate.resolution
 
+
 def test_disable_invalid_channel(connected_waveplate):
     with pytest.raises(WaveplateInvalidMotorChannelError):
         # Waveplates has max channel of 1
         connected_waveplate.disable_channel(2)
+
 
 def test_enable_duplicate_channel(connected_waveplate):
     connected_waveplate.disable_channel(1)
@@ -60,11 +86,13 @@ def test_enable_duplicate_channel(connected_waveplate):
     # Make sure there is only one channel 1
     assert len(connected_waveplate.enabled_channels) == 1
 
+
 def test_step_forward(connected_waveplate):
     connected_waveplate.rotate(90)
     original_position = connected_waveplate.getpos()
     connected_waveplate.step_forward(10)
     assert connected_waveplate.getpos() == original_position + 10
+
 
 def test_step_backward(connected_waveplate):
     connected_waveplate.rotate(90)
@@ -72,19 +100,26 @@ def test_step_backward(connected_waveplate):
     connected_waveplate.step_backward(10)
     assert connected_waveplate.getpos() == original_position - 10
 
+
 def test_invalid_steps_backward(connected_waveplate):
     with pytest.raises(WaveplateInvalidStepsError):
         connected_waveplate.step_backward(1)
+
 
 def test_invalid_steps_forward(connected_waveplate):
     with pytest.raises(WaveplateInvalidStepsError):
         connected_waveplate.step_forward(connected_waveplate.max_steps + 1)
 
+
 def test_rotate_relative(connected_waveplate):
     connected_waveplate.rotate(90)
     original_position = connected_waveplate.getpos()
     connected_waveplate.rotate_relative(10)
-    assert connected_waveplate.getpos() == original_position + 10 * connected_waveplate.resolution
+    assert (
+        connected_waveplate.getpos()
+        == original_position + 10 * connected_waveplate.resolution
+    )
+
 
 def test_custom_home(connected_waveplate):
     connected_waveplate.custom_home(45)


### PR DESCRIPTION
This fixes all formatting and static analysis errors found by the current `check.bash` script.

In the future, any PR that introduces a new error will fail. Errors will need to be corrected before merging.