### PR TITLE
Add pint to MPC320

### DIFF
--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -1,3 +1,4 @@
+from pint import DimensionalityError
 import pytest
 
 from pnpq.apt.protocol import ChanIdent
@@ -73,9 +74,12 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # device.move_absolute(ChanIdent.CHANNEL_3, 0 * ureg.degree)
 
 
-def test_illegal_angles(device: PolarizationControllerThorlabsMPC320) -> None:
+def test_invalid_angle_inputs(device: PolarizationControllerThorlabsMPC320) -> None:
     device.identify(ChanIdent.CHANNEL_1)
 
     with pytest.raises(ValueError):
         device.move_absolute(ChanIdent.CHANNEL_1, 171 * ureg.degree)
         device.move_absolute(ChanIdent.CHANNEL_1, -1 * ureg.degree)
+
+    with pytest.raises(DimensionalityError):
+        device.move_absolute(ChanIdent.CHANNEL_1, 1 * ureg.meter)

--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -1,5 +1,5 @@
-from pint import DimensionalityError
 import pytest
+from pint import DimensionalityError
 
 from pnpq.apt.protocol import ChanIdent
 from pnpq.devices.polarization_controller_thorlabs_mpc320 import (

--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -4,6 +4,7 @@ from pnpq.apt.protocol import ChanIdent
 from pnpq.devices.polarization_controller_thorlabs_mpc320 import (
     PolarizationControllerThorlabsMPC320,
 )
+from pnpq.units import ureg
 
 
 @pytest.fixture(name="device", scope="module")
@@ -23,21 +24,21 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     device.home(ChanIdent.CHANNEL_2)
     device.home(ChanIdent.CHANNEL_3)
 
-    device.move_absolute(ChanIdent.CHANNEL_1, 160)
-    device.move_absolute(ChanIdent.CHANNEL_2, 160)
-    device.move_absolute(ChanIdent.CHANNEL_3, 160)
+    device.move_absolute(ChanIdent.CHANNEL_1, 160 * ureg.degree)
+    device.move_absolute(ChanIdent.CHANNEL_2, 160 * ureg.degree)
+    device.move_absolute(ChanIdent.CHANNEL_3, 160 * ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_2, 30)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 90)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 90)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 30 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 90 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 90 * ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_3, 165)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 90)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 0)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 165 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 90 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 100)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 50)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 100 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 50 * ureg.degree)
 
     device.home(ChanIdent.CHANNEL_1)
     device.home(ChanIdent.CHANNEL_2)
@@ -47,9 +48,9 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # off its motor when it's homed or set to 0 degrees. It just sits
     # there vibrating and whining. It's not really safe to leave the
     # device at degree 0 for this reason. 170 also seems too far (160 seems about the safest)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 10)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 10)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * ureg.degree)
 
     # device.set_params(home_position=1000)
 
@@ -57,16 +58,16 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # device.home(ChanIdent.CHANNEL_2)
     # device.home(ChanIdent.CHANNEL_3)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 10)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 10)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * ureg.degree)
 
-    # device.set_params(home_position=0)
+    # device.set_params(home_position=0 * ureg.degree)
 
     # device.home(ChanIdent.CHANNEL_1)
     # device.home(ChanIdent.CHANNEL_2)
     # device.home(ChanIdent.CHANNEL_3)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 0)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 0)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 0)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 0 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 0 * ureg.degree)

--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -71,3 +71,11 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # device.move_absolute(ChanIdent.CHANNEL_1, 0 * ureg.degree)
     # device.move_absolute(ChanIdent.CHANNEL_2, 0 * ureg.degree)
     # device.move_absolute(ChanIdent.CHANNEL_3, 0 * ureg.degree)
+
+
+def test_illegal_angles(device: PolarizationControllerThorlabsMPC320) -> None:
+    device.identify(ChanIdent.CHANNEL_1)
+
+    with pytest.raises(ValueError):
+        device.move_absolute(ChanIdent.CHANNEL_1, 171 * ureg.degree)
+        device.move_absolute(ChanIdent.CHANNEL_1, -1 * ureg.degree)

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -427,7 +427,7 @@ class PolarizationControllerThorlabsMPC320:
             ) from exc
         if absolute_degree < 0 or absolute_degree > 170:
             raise ValueError(
-                f"Provided value must be between 0 and 170 degrees (or equivalent). Value given was {absolute_degree} degrees."
+                f"Absolute position must be between 0 and 170 degrees (or equivalent). Value given was {absolute_degree} degrees."
             )
         self.set_channel_enabled(chan_ident, True)
         self.log.debug("Sending move_absolute command...")

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -8,7 +8,7 @@ from typing import Callable, Iterator, Optional, Tuple
 
 import serial.tools.list_ports
 import structlog
-from pint import DimensionalityError, Quantity
+from pint import Quantity
 from serial import Serial
 
 import pnpq.apt

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -418,13 +418,8 @@ class PolarizationControllerThorlabsMPC320:
 
     def move_absolute(self, chan_ident: ChanIdent, position: Quantity) -> None:
         # Convert distance to mpc320 steps and check for errors
-        try:
-            absolute_distance = round(position.to("mpc320_step").magnitude)
-            absolute_degree = round(position.to("degree").magnitude)
-        except DimensionalityError as exc:
-            raise ValueError(
-                f"Quantity {position} cannot be converted to mpc320_step."
-            ) from exc
+        absolute_distance = round(position.to("mpc320_step").magnitude)
+        absolute_degree = round(position.to("degree").magnitude)
         if absolute_degree < 0 or absolute_degree > 170:
             raise ValueError(
                 f"Absolute position must be between 0 and 170 degrees (or equivalent). Value given was {absolute_degree} degrees."

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -3,4 +3,4 @@ import pint
 ureg = pint.UnitRegistry()
 
 # Custom unit definitions
-ureg.define('mpc320_step = (170 / 1370) degree') # MPC320
+ureg.define("mpc320_step = (170 / 1370) degree")  # MPC320

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -1,3 +1,6 @@
 import pint
 
 ureg = pint.UnitRegistry()
+
+# Custom unit definitions
+ureg.define('mpc320_step = (170 / 1370) degree') # MPC320


### PR DESCRIPTION
Closes #57 

I didn't test this code on real hardware since I didn't have access to one from writing this software. It would be nice if @auspicacious can try it (or I can try it on Friday). 

I implemented pint for `move_absolute` function (in parameter) as well as the `home_position` of the `PolarizationControllerParams` struct.