### PR TITLE
Ensure that motor_current is actually a quantity of type current.

### DIFF
--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -435,7 +435,9 @@ class AptMessageWithDataMotorStatus(AptMessageWithData):
     status: Status
 
     def __post_init__(self) -> None:
-        self.motor_current.check("[current]")
+        # Ensure that a unit of current was passed in by attempting to
+        # convert it to milliamps.
+        self.motor_current.to(ureg.milliamp)
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> Self:

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -1,4 +1,6 @@
 # pylint: disable=C0103
+import pytest
+from pint import DimensionalityError
 
 from pnpq.apt.protocol import (
     Address,
@@ -256,6 +258,19 @@ def test_AptMessage_MGMSG_MOT_GET_USTATUSUPDATE_to_bytes() -> None:
     assert msg.to_bytes() == bytes.fromhex(
         "9104 0e00 81 22 0100 01000000 0100 FFFF 07000000"
     )
+
+
+def test_AptMessage_MGMSG_MOT_GET_USTATUSUPDATE_invalid_unit() -> None:
+    with pytest.raises(DimensionalityError):
+        AptMessage_MGMSG_MOT_GET_USTATUSUPDATE(
+            destination=Address.HOST_CONTROLLER,
+            source=Address.BAY_1,
+            chan_ident=ChanIdent.CHANNEL_1,
+            position=1,
+            velocity=1,
+            motor_current=(-1 * ureg.meter),
+            status=Status(CWHARDLIMIT=True, CCWHARDLIMIT=True, CWSOFTLIMIT=True),
+        )
 
 
 def test_AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE_from_bytes() -> None:


### PR DESCRIPTION
As @TomShen1234 pointed out, the `.check()` function returns a boolean and does not throw an exception, meaning that the existing code was not working as expected.

I attempted to use Pint's `check` decorator by redefining `motor_current` as a `@property` and creating a decorated setter function, but Python's property decorators do not seem to co-exist well with dataclasses, mypy, ruff, or pylint.