### PR TITLE
add 3 more messages: MOVE_JOG, MOVE_STOP, MOVE_STOPPED

### DIFF
--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -146,8 +146,8 @@ class StopMode(int, Enum):
 class JogDirection(int, Enum):
     """Used in MSMSG_MOT_MOVE_JOG."""
 
-    JOG_FORWARD = 0x01
-    JOG_BACKWARD = 0x02
+   FORWARD = 0x01
+   REVERSE = 0x02
 
 
 @enum.unique

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -146,8 +146,8 @@ class StopMode(int, Enum):
 class JogDirection(int, Enum):
     """Used in MSMSG_MOT_MOVE_JOG."""
 
-   FORWARD = 0x01
-   REVERSE = 0x02
+    FORWARD = 0x01
+    REVERSE = 0x02
 
 
 @enum.unique

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -949,13 +949,8 @@ class AptMessage_MGMSG_MOT_MOVE_JOG(AptMessageHeaderOnly):
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_MOVE_STOPPED(AptMessageHeaderOnlyChanIdent):
     """Note that the APT documentation indicates that this should be
-    followed by a full USTATUS data packet.
-
-    MGMSG_MOT_MOVE_COMPLETED is a similar message that is also expected to be
-    followed by a USTATUS packet. For MOVE_COMPLETED, in reality no data packet
-    follows for the MPC320, so further testing is required if this is also true
-    for MOVE_STOPPED.
-    """
+    followed by a full USTATUS data packet. In reality, for the
+    MPC320, no data packet follows."""
 
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_STOPPED
 

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -138,8 +138,8 @@ class EnableState(int, Enum):
 class StopMode(int, Enum):
     """Used in MSMSG_MOT_MOVE_STOP."""
 
-    IMMEDIATE_STOP = 0x01
-    CONTROLLED_STOP = 0x02
+    IMMEDIATE = 0x01
+    CONTROLLED = 0x02
 
 
 @enum.unique

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -523,7 +523,7 @@ def test_AptMessage_MGMSG_MOT_MOVE_JOG_to_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_MOVE_JOG(
         chan_ident=ChanIdent.CHANNEL_1,
         destination=Address.GENERIC_USB,
-        jog_direction=JogDirection.JOG_FORWARD,
+        jog_direction=JogDirection.FORWARD,
         source=Address.HOST_CONTROLLER,
     )
     assert msg.to_bytes() == b"\x6A\x04\x01\x01\x50\x01"
@@ -542,7 +542,7 @@ def test_AptMessage_MGMSG_MOT_MOVE_STOP_to_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_MOVE_STOP(
         chan_ident=ChanIdent.CHANNEL_1,
         destination=Address.GENERIC_USB,
-        stop_mode=StopMode.IMMEDIATE_STOP,
+        stop_mode=StopMode.IMMEDIATE,
         source=Address.HOST_CONTROLLER,
     )
     assert msg.to_bytes() == b"\x65\x04\x01\x01\x50\x01"

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -20,6 +20,9 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_MOVE_COMPLETED,
     AptMessage_MGMSG_MOT_MOVE_HOME,
     AptMessage_MGMSG_MOT_MOVE_HOMED,
+    AptMessage_MGMSG_MOT_MOVE_JOG,
+    AptMessage_MGMSG_MOT_MOVE_STOP,
+    AptMessage_MGMSG_MOT_MOVE_STOPPED,
     AptMessage_MGMSG_MOT_REQ_POSCOUNTER,
     AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_SET_POSCOUNTER,
@@ -31,7 +34,9 @@ from pnpq.apt.protocol import (
     EnableState,
     FirmwareVersion,
     HardwareType,
+    JogDirection,
     Status,
+    StopMode,
 )
 from pnpq.units import ureg
 
@@ -503,6 +508,61 @@ def test_AptMessage_MGMSG_POL_SET_PARAMS_from_bytes() -> None:
     assert msg.jog_step_1 == 25
     assert msg.jog_step_2 == 25
     assert msg.jog_step_3 == 25
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_JOG_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_JOG.from_bytes(b"\x6A\x04\x01\x02\x01\x50")
+    assert msg.message_id == 0x046A
+    assert msg.chan_ident == 0x01
+    assert msg.jog_direction == 0x02
+    assert msg.destination == 0x01
+    assert msg.source == 0x50
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_JOG_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_JOG(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.GENERIC_USB,
+        jog_direction=JogDirection.JOG_FORWARD,
+        source=Address.HOST_CONTROLLER,
+    )
+    assert msg.to_bytes() == b"\x6A\x04\x01\x01\x50\x01"
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_STOP_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_STOP.from_bytes(b"\x65\x04\x01\x01\x50\x01")
+    assert msg.message_id == 0x0465
+    assert msg.chan_ident == 0x01
+    assert msg.stop_mode == 0x01
+    assert msg.destination == 0x50
+    assert msg.source == 0x01
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_STOP_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_STOP(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.GENERIC_USB,
+        stop_mode=StopMode.IMMEDIATE_STOP,
+        source=Address.HOST_CONTROLLER,
+    )
+    assert msg.to_bytes() == b"\x65\x04\x01\x01\x50\x01"
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_STOPPED_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_STOPPED.from_bytes(bytes.fromhex("6604 0100 01 22"))
+    assert msg.destination == 0x01
+    assert msg.message_id == 0x0466
+    assert msg.source == 0x22
+    assert msg.chan_ident == 0x01
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_STOPPED_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_STOPPED(
+        destination=Address.HOST_CONTROLLER,
+        source=Address.BAY_1,
+        chan_ident=ChanIdent.CHANNEL_1,
+    )
+    assert msg.to_bytes() == bytes.fromhex("6604 0100 01 22")
 
 
 def test_AptMessage_MGMSG_RESTOREFACTORYSETTINGS_from_bytes() -> None:


### PR DESCRIPTION
Partial implementation of #56 

Attempted to implement 3 more messages: MOVE_JOG, MOVE_STOP, MOVE_STOPPED
Created 2 new enums in the process: StopMode and JogDirection.

MOVE_JOG and MOVE_STOP use very similar code, so I am wondering if there's a better way to do this.

Also, while I have implemented the first 6 bytes of MSMSG_MOT_MOVE_STOPPED, the entire message is supposed to be 20 bytes. However, a similar message (MGMSG_MOT_MOVE_COMPLETED) is also in a similar format, but in reality the MPC320  does not follow up with the extra 14 bytes. So I have left it unfinished for now. 