### PR TITLE
Add sleep after sending no-reply commands.

### DIFF
--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -90,10 +90,11 @@ class PolarizationControllerThorlabsMPC320:
                     )
                 )
                 # If we are currently waiting for a reply to a message
-                # we sent, poll every 0.2 seconds to ensure quick
-                # response to state changes. If we are not waiting for
-                # a reply, poll at least once every second to reduce
-                # the amount of noise in logs.
+                # we sent, poll every 0.2 seconds to ensure a
+                # relatively quick response to state changes that we
+                # observe using status update messages. If we are not
+                # waiting for a reply, poll at least once every second
+                # to reduce the amount of noise in logs.
                 #
                 # The tx_ordered_sender thread can request a faster
                 # update by setting the
@@ -104,9 +105,9 @@ class PolarizationControllerThorlabsMPC320:
                     # The documentation for
                     # MGMSG_MOT_ACK_USTATUSUPDATE suggests that it
                     # should be sent at least once a second. This will
-                    # probably send slightly _less_ than once a
-                    # second, so, if we start having issues, we should
-                    # decrease this interval.
+                    # probably send slightly less frequently than once
+                    # a second, so, if we start having issues, we
+                    # should decrease this interval.
                     self.connection.tx_ordered_sender_awaiting_reply.wait(1)
 
     def home(self, chan_ident: ChanIdent) -> None:


### PR DESCRIPTION
One-line code change with a lot of explanatory comments.

@TomShen1234 @master-of-ppap I think that we should merge this PR, then, after @master-of-ppap finishes writing the driver implementation for `jog` in a separate PR, we should re-test on the hardware.

I am a little concerned that this will add 0.4 seconds to every move command. We might be able to tune this downward a little. But we have to disable the channel after each move if we want to use the device accurately, since otherwise it will just sit there vibrating, and that means having some kind of short delay.