### PR TITLE
Changed MPC320 parameters to TypedDict

### DIFF
--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -84,3 +84,29 @@ def test_invalid_angle_inputs(device: PolarizationControllerThorlabsMPC320) -> N
 
     with pytest.raises(DimensionalityError):
         device.move_absolute(ChanIdent.CHANNEL_1, 1 * ureg.meter)
+
+
+def test_set_params(device: PolarizationControllerThorlabsMPC320) -> None:
+    device.identify(ChanIdent.CHANNEL_1)
+
+    device.home(ChanIdent.CHANNEL_1)
+    device.home(ChanIdent.CHANNEL_2)
+    device.home(ChanIdent.CHANNEL_3)
+
+    # Set a custom home position
+    params = device.get_params()
+    params["home_position"] = 100 * ureg.degree
+    device.set_params(**params)
+
+    device.home(ChanIdent.CHANNEL_1)
+    device.home(ChanIdent.CHANNEL_2)
+    device.home(ChanIdent.CHANNEL_3)
+
+    # Reset the home position
+    params = device.get_params()
+    params["home_position"] = 0 * ureg.degree
+    device.set_params(**params)
+
+    device.home(ChanIdent.CHANNEL_1)
+    device.home(ChanIdent.CHANNEL_2)
+    device.home(ChanIdent.CHANNEL_3)

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -226,7 +226,7 @@ class PolarizationControllerThorlabsMPC320:
                 destination=Address.GENERIC_USB,
                 source=Address.HOST_CONTROLLER,
                 velocity=params["velocity"],
-                home_position=params["home_position"].magnitude,
+                home_position=round(params["home_position"].magnitude),
                 jog_step_1=params["jog_step_1"],
                 jog_step_2=params["jog_step_2"],
                 jog_step_3=params["jog_step_3"],

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -62,8 +62,6 @@ class PolarizationControllerThorlabsMPC320:
         )
         self.tx_poller_thread.start()
 
-        self.refresh_params()
-
     # Polling thread for sending status update requests
     def tx_poll(self) -> None:
         with self.tx_poller_thread_lock:
@@ -162,7 +160,7 @@ class PolarizationControllerThorlabsMPC320:
         self.log.debug("move_absolute command finished", elapsed_time=elapsed_time)
         self.set_channel_enabled(chan_ident, False)
 
-    def refresh_params(self) -> PolarizationControllerParams:
+    def get_params(self) -> PolarizationControllerParams:
         params = self.connection.send_message_expect_reply(
             AptMessage_MGMSG_POL_REQ_PARAMS(
                 destination=Address.GENERIC_USB,
@@ -210,7 +208,7 @@ class PolarizationControllerThorlabsMPC320:
         jog_step_3: None | int = None,
     ) -> None:
         # First load existing params
-        params = self.refresh_params()
+        params = self.get_params()
         # Replace params that need to be changed
         if velocity is not None:
             params["velocity"] = velocity
@@ -234,4 +232,3 @@ class PolarizationControllerThorlabsMPC320:
                 jog_step_3=params["jog_step_3"],
             )
         )
-        time.sleep(1)

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import TypedDict, cast
 
 import structlog
 from pint import Quantity
@@ -213,7 +213,7 @@ class PolarizationControllerThorlabsMPC320:
         if velocity is not None:
             params["velocity"] = velocity
         if home_position is not None:
-            params["home_position"] = home_position
+            params["home_position"] = cast(Quantity, home_position.to("mpc320_step"))
         if jog_step_1 is not None:
             params["jog_step_1"] = jog_step_1
         if jog_step_2 is not None:


### PR DESCRIPTION
Closes #68 

I have yet to test this code on the real device. It would be nice if I can have some support on that. 

I removed the `dataclass` decorator on `PolarizationControllerParams`, and changed it into a `TypedDict`. The class property is also removed in favor of `refresh_params` returning the dictionary. 

The only change is that the parameter now have to be used with the dictionary syntax rather than a class (which requires some string accessed variables). Let's discuss whether this is ideal. 

The interface for `set_params` remains unchanged, with the underlying logic changed to fetch the current params, update the dictionary, and sending the updated dictionary back to the device. 