### PR TITLE
Support pint's Quantity for other PolarizationControllerParams fields

### DIFF
--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -78,15 +78,15 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
 def test_jog(device: PolarizationControllerThorlabsMPC320) -> None:
 
     params = device.get_params()
-    old_jog_step_1 = params["jog_step_1"]
-    old_jog_step_2 = params["jog_step_2"]
-    old_jog_step_3 = params["jog_step_3"]
+    old_jog_step_1 = params["jog_step_1"] * ureg.mpc320_step
+    old_jog_step_2 = params["jog_step_2"] * ureg.mpc320_step
+    old_jog_step_3 = params["jog_step_3"] * ureg.mpc320_step
 
     device.home(ChanIdent.CHANNEL_1)
     device.home(ChanIdent.CHANNEL_2)
     device.home(ChanIdent.CHANNEL_3)
 
-    jog_step = 50
+    jog_step = 50 * ureg.mpc320_step
     jog_count = 5
 
     device.set_params(jog_step_1=jog_step, jog_step_2=jog_step, jog_step_3=jog_step)
@@ -108,9 +108,9 @@ def test_jog(device: PolarizationControllerThorlabsMPC320) -> None:
 
     # Validate that we jogged to the expected position.
     # If we are at the correct position, this move_absolute command should not cause the device to move.
-    device.move_absolute(ChanIdent.CHANNEL_1, jog_count * jog_step * ureg.mpc320_step)
-    device.move_absolute(ChanIdent.CHANNEL_2, jog_count * jog_step * ureg.mpc320_step)
-    device.move_absolute(ChanIdent.CHANNEL_3, jog_count * jog_step * ureg.mpc320_step)
+    device.move_absolute(ChanIdent.CHANNEL_1, jog_count * jog_step)
+    device.move_absolute(ChanIdent.CHANNEL_2, jog_count * jog_step)
+    device.move_absolute(ChanIdent.CHANNEL_3, jog_count * jog_step)
 
 
 def test_invalid_angle_inputs(device: PolarizationControllerThorlabsMPC320) -> None:

--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -6,7 +6,7 @@ from pnpq.apt.protocol import ChanIdent, JogDirection
 from pnpq.devices.polarization_controller_thorlabs_mpc320 import (
     PolarizationControllerThorlabsMPC320,
 )
-from pnpq.units import ureg
+from pnpq.units import pnpq_ureg
 
 
 @pytest.fixture(name="device", scope="module")
@@ -26,21 +26,21 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     device.home(ChanIdent.CHANNEL_2)
     device.home(ChanIdent.CHANNEL_3)
 
-    device.move_absolute(ChanIdent.CHANNEL_1, 160 * ureg.degree)
-    device.move_absolute(ChanIdent.CHANNEL_2, 160 * ureg.degree)
-    device.move_absolute(ChanIdent.CHANNEL_3, 160 * ureg.degree)
+    device.move_absolute(ChanIdent.CHANNEL_1, 160 * pnpq_ureg.degree)
+    device.move_absolute(ChanIdent.CHANNEL_2, 160 * pnpq_ureg.degree)
+    device.move_absolute(ChanIdent.CHANNEL_3, 160 * pnpq_ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_2, 30 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 90 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 90 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 30 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 90 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 90 * pnpq_ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_3, 165 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 90 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 165 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 90 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * pnpq_ureg.degree)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 100 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 50 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 100 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 50 * pnpq_ureg.degree)
 
     device.home(ChanIdent.CHANNEL_1)
     device.home(ChanIdent.CHANNEL_2)
@@ -50,9 +50,9 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # off its motor when it's homed or set to 0 degrees. It just sits
     # there vibrating and whining. It's not really safe to leave the
     # device at degree 0 for this reason. 170 also seems too far (160 seems about the safest)
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * pnpq_ureg.degree)
 
     # device.set_params(home_position=1000)
 
@@ -60,19 +60,19 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
     # device.home(ChanIdent.CHANNEL_2)
     # device.home(ChanIdent.CHANNEL_3)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 10 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 10 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 10 * pnpq_ureg.degree)
 
-    # device.set_params(home_position=0 * ureg.degree)
+    # device.set_params(home_position=0 * pnpq_ureg.degree)
 
     # device.home(ChanIdent.CHANNEL_1)
     # device.home(ChanIdent.CHANNEL_2)
     # device.home(ChanIdent.CHANNEL_3)
 
-    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_2, 0 * ureg.degree)
-    # device.move_absolute(ChanIdent.CHANNEL_3, 0 * ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_1, 0 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_2, 0 * pnpq_ureg.degree)
+    # device.move_absolute(ChanIdent.CHANNEL_3, 0 * pnpq_ureg.degree)
 
 
 def test_jog(device: PolarizationControllerThorlabsMPC320) -> None:
@@ -86,13 +86,13 @@ def test_jog(device: PolarizationControllerThorlabsMPC320) -> None:
     device.home(ChanIdent.CHANNEL_2)
     device.home(ChanIdent.CHANNEL_3)
 
-    jog_step = 50 * ureg.mpc320_step
+    jog_step = 50 * pnpq_ureg.mpc320_step
     jog_count = 5
 
     device.set_params(jog_step_1=jog_step, jog_step_2=jog_step, jog_step_3=jog_step)
 
     # Home should be set to 0 for this test to work
-    # device.set_params(home_position=0*ureg.degree)
+    # device.set_params(home_position=0*pnpq_ureg.degree)
 
     try:
         for _ in range(jog_count):
@@ -117,11 +117,11 @@ def test_invalid_angle_inputs(device: PolarizationControllerThorlabsMPC320) -> N
     device.identify(ChanIdent.CHANNEL_1)
 
     with pytest.raises(ValueError):
-        device.move_absolute(ChanIdent.CHANNEL_1, 171 * ureg.degree)
-        device.move_absolute(ChanIdent.CHANNEL_1, -1 * ureg.degree)
+        device.move_absolute(ChanIdent.CHANNEL_1, 171 * pnpq_ureg.degree)
+        device.move_absolute(ChanIdent.CHANNEL_1, -1 * pnpq_ureg.degree)
 
     with pytest.raises(DimensionalityError):
-        device.move_absolute(ChanIdent.CHANNEL_1, 1 * ureg.meter)
+        device.move_absolute(ChanIdent.CHANNEL_1, 1 * pnpq_ureg.meter)
 
 
 def test_set_params(device: PolarizationControllerThorlabsMPC320) -> None:
@@ -133,7 +133,7 @@ def test_set_params(device: PolarizationControllerThorlabsMPC320) -> None:
 
     # Set a custom home position
     params = device.get_params()
-    params["home_position"] = 100 * ureg.degree
+    params["home_position"] = 100 * pnpq_ureg.degree
     device.set_params(**params)
 
     device.home(ChanIdent.CHANNEL_1)
@@ -142,7 +142,7 @@ def test_set_params(device: PolarizationControllerThorlabsMPC320) -> None:
 
     # Reset the home position
     params = device.get_params()
-    params["home_position"] = 0 * ureg.degree
+    params["home_position"] = 0 * pnpq_ureg.degree
     device.set_params(**params)
 
     device.home(ChanIdent.CHANNEL_1)

--- a/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/hardware_tests/test_polarization_controller_thorlabs_mpc320.py
@@ -78,9 +78,9 @@ def test_move_absolute(device: PolarizationControllerThorlabsMPC320) -> None:
 def test_jog(device: PolarizationControllerThorlabsMPC320) -> None:
 
     params = device.get_params()
-    old_jog_step_1 = params["jog_step_1"] * ureg.mpc320_step
-    old_jog_step_2 = params["jog_step_2"] * ureg.mpc320_step
-    old_jog_step_3 = params["jog_step_3"] * ureg.mpc320_step
+    old_jog_step_1 = params["jog_step_1"]
+    old_jog_step_2 = params["jog_step_2"]
+    old_jog_step_3 = params["jog_step_3"]
 
     device.home(ChanIdent.CHANNEL_1)
     device.home(ChanIdent.CHANNEL_2)

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -6,24 +6,24 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'PnPQ'
-copyright = '2024, PnPQ contributors'
-author = 'PnPQ contributors'
+project = "PnPQ"
+copyright = "2024, PnPQ contributors"
+author = "PnPQ contributors"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinxcontrib.apidoc',
+    "sphinxcontrib.apidoc",
 ]
-apidoc_module_dir = '../../src'
+apidoc_module_dir = "../../src"
 autodoc_typehints = "description"
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns: list[str] = []
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -10,7 +10,7 @@ from typing import ClassVar, Self
 
 from pint import Quantity
 
-from ..units import ureg
+from ..units import pnpq_ureg
 
 
 @enum.unique
@@ -497,7 +497,7 @@ class AptMessageWithDataMotorStatus(AptMessageWithData):
     def __post_init__(self) -> None:
         # Ensure that a unit of current was passed in by attempting to
         # convert it to milliamps.
-        self.motor_current.to(ureg.milliamp)
+        self.motor_current.to(pnpq_ureg.milliamp)
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> Self:
@@ -532,7 +532,7 @@ class AptMessageWithDataMotorStatus(AptMessageWithData):
             chan_ident=ChanIdent(chan_ident),
             position=position,
             velocity=velocity,
-            motor_current=(motor_current * ureg.milliamp),
+            motor_current=(motor_current * pnpq_ureg.milliamp),
             status=Status.from_bits(StatusBits(status_flag)),
         )
 
@@ -545,7 +545,7 @@ class AptMessageWithDataMotorStatus(AptMessageWithData):
             self.chan_ident,
             self.position,
             self.velocity,
-            round(self.motor_current.to(ureg.milliamp).magnitude),
+            round(self.motor_current.to(pnpq_ureg.milliamp).magnitude),
             self.status.to_bits(),
         )
 

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -32,9 +32,9 @@ from ..units import ureg
 class PolarizationControllerParams(TypedDict):
     velocity: int
     home_position: Quantity
-    jog_step_1: int
-    jog_step_2: int
-    jog_step_3: int
+    jog_step_1: Quantity
+    jog_step_2: Quantity
+    jog_step_3: Quantity
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -205,9 +205,9 @@ class PolarizationControllerThorlabsMPC320:
         result: PolarizationControllerParams = {
             "velocity": params.velocity,
             "home_position": params.home_position * ureg.mpc320_step,
-            "jog_step_1": params.jog_step_1,
-            "jog_step_2": params.jog_step_2,
-            "jog_step_3": params.jog_step_3,
+            "jog_step_1": params.jog_step_1 * ureg.mpc320_step,
+            "jog_step_2": params.jog_step_2 * ureg.mpc320_step,
+            "jog_step_3": params.jog_step_3 * ureg.mpc320_step,
         }
         return result
 
@@ -236,9 +236,9 @@ class PolarizationControllerThorlabsMPC320:
         self,
         velocity: None | int = None,
         home_position: None | Quantity = None,
-        jog_step_1: None | int = None,
-        jog_step_2: None | int = None,
-        jog_step_3: None | int = None,
+        jog_step_1: None | Quantity = None,
+        jog_step_2: None | Quantity = None,
+        jog_step_3: None | Quantity = None,
     ) -> None:
         # First load existing params
 
@@ -249,11 +249,11 @@ class PolarizationControllerThorlabsMPC320:
         if home_position is not None:
             params["home_position"] = cast(Quantity, home_position.to("mpc320_step"))
         if jog_step_1 is not None:
-            params["jog_step_1"] = jog_step_1
+            params["jog_step_1"] = cast(Quantity, jog_step_1.to("mpc320_step"))
         if jog_step_2 is not None:
-            params["jog_step_2"] = jog_step_2
+            params["jog_step_2"] = cast(Quantity, jog_step_2.to("mpc320_step"))
         if jog_step_3 is not None:
-            params["jog_step_3"] = jog_step_3
+            params["jog_step_3"] = cast(Quantity, jog_step_3.to("mpc320_step"))
         # Send params to device
         self.connection.send_message_no_reply(
             AptMessage_MGMSG_POL_SET_PARAMS(
@@ -261,8 +261,8 @@ class PolarizationControllerThorlabsMPC320:
                 source=Address.HOST_CONTROLLER,
                 velocity=params["velocity"],
                 home_position=round(params["home_position"].magnitude),
-                jog_step_1=params["jog_step_1"],
-                jog_step_2=params["jog_step_2"],
-                jog_step_3=params["jog_step_3"],
+                jog_step_1=round(params["jog_step_1"].magnitude),
+                jog_step_2=round(params["jog_step_2"].magnitude),
+                jog_step_3=round(params["jog_step_3"].magnitude),
             )
         )

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -26,7 +26,7 @@ from ..apt.protocol import (
     EnableState,
     JogDirection,
 )
-from ..units import ureg
+from ..units import pnpq_ureg
 
 
 class PolarizationControllerParams(TypedDict):
@@ -208,11 +208,11 @@ class PolarizationControllerThorlabsMPC320:
         )
         assert isinstance(params, AptMessage_MGMSG_POL_GET_PARAMS)
         result: PolarizationControllerParams = {
-            "velocity": params.velocity * ureg.mpc320_velocity,
-            "home_position": params.home_position * ureg.mpc320_step,
-            "jog_step_1": params.jog_step_1 * ureg.mpc320_step,
-            "jog_step_2": params.jog_step_2 * ureg.mpc320_step,
-            "jog_step_3": params.jog_step_3 * ureg.mpc320_step,
+            "velocity": params.velocity * pnpq_ureg.mpc320_velocity,
+            "home_position": params.home_position * pnpq_ureg.mpc320_step,
+            "jog_step_1": params.jog_step_1 * pnpq_ureg.mpc320_step,
+            "jog_step_2": params.jog_step_2 * pnpq_ureg.mpc320_step,
+            "jog_step_3": params.jog_step_3 * pnpq_ureg.mpc320_step,
         }
         return result
 

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -30,7 +30,7 @@ from ..units import ureg
 
 
 class PolarizationControllerParams(TypedDict):
-    velocity: int
+    velocity: Quantity
     home_position: Quantity
     jog_step_1: Quantity
     jog_step_2: Quantity
@@ -203,7 +203,7 @@ class PolarizationControllerThorlabsMPC320:
         )
         assert isinstance(params, AptMessage_MGMSG_POL_GET_PARAMS)
         result: PolarizationControllerParams = {
-            "velocity": params.velocity,
+            "velocity": params.velocity * ureg.mpc320_velocity,
             "home_position": params.home_position * ureg.mpc320_step,
             "jog_step_1": params.jog_step_1 * ureg.mpc320_step,
             "jog_step_2": params.jog_step_2 * ureg.mpc320_step,
@@ -234,7 +234,7 @@ class PolarizationControllerThorlabsMPC320:
 
     def set_params(
         self,
-        velocity: None | int = None,
+        velocity: None | Quantity = None,
         home_position: None | Quantity = None,
         jog_step_1: None | Quantity = None,
         jog_step_2: None | Quantity = None,
@@ -245,7 +245,7 @@ class PolarizationControllerThorlabsMPC320:
         params = self.get_params()
         # Replace params that need to be changed
         if velocity is not None:
-            params["velocity"] = velocity
+            params["velocity"] = cast(Quantity, velocity.to("mpc320_velocity"))
         if home_position is not None:
             params["home_position"] = cast(Quantity, home_position.to("mpc320_step"))
         if jog_step_1 is not None:
@@ -259,7 +259,7 @@ class PolarizationControllerThorlabsMPC320:
             AptMessage_MGMSG_POL_SET_PARAMS(
                 destination=Address.GENERIC_USB,
                 source=Address.HOST_CONTROLLER,
-                velocity=params["velocity"],
+                velocity=round(params["velocity"].magnitude),
                 home_position=round(params["home_position"].magnitude),
                 jog_step_1=round(params["jog_step_1"].magnitude),
                 jog_step_2=round(params["jog_step_2"].magnitude),

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc320.py
@@ -30,10 +30,15 @@ from ..units import ureg
 
 
 class PolarizationControllerParams(TypedDict):
+    #: Dimensionality must be ([angle] / [time]) or mpc320_velocity
     velocity: Quantity
+    #: Dimensionality must be [angle] or mpc320_step
     home_position: Quantity
+    #: Dimensionality must be [angle] or mpc320_step
     jog_step_1: Quantity
+    #: Dimensionality must be [angle] or mpc320_step
     jog_step_2: Quantity
+    #: Dimensionality must be [angle] or mpc320_step
     jog_step_3: Quantity
 
 

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -8,7 +8,13 @@ ureg = pint.UnitRegistry()
 # Custom unit definitions for MPC320
 ureg.define("mpc320_step = (170 / 1370) degree")
 ureg.define("mpc320_max_velocity = 400 degree / second")
+
+# According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
+# The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
+# Thus, the unit for mpc_velocity will be set as dimensionless.
+# A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
 ureg.define("mpc320_velocity = []")
+
 
 context = pint.Context("mpc320_proportional_velocity")
 

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -1,6 +1,4 @@
 import pint
-from pint import Quantity
-from typing import cast
 
 ureg = pint.UnitRegistry()
 
@@ -22,13 +20,15 @@ mpc320_max_velocity = 400 * (ureg.degree / ureg.second)
 context.add_transformation(
     "degree / second",
     "mpc320_velocity",
-    lambda ureg, value, **kwargs: (value / mpc320_max_velocity) * 100, # Convert value to percent
+    lambda ureg, value, **kwargs: (value / mpc320_max_velocity)
+    * 100,  # Convert value to percent
 )
 
 context.add_transformation(
     "mpc320_velocity",
     "degree / second",
-    lambda ureg, value, **kwargs: (value * mpc320_max_velocity) / 100, # Convert value from percent
+    lambda ureg, value, **kwargs: (value * mpc320_max_velocity)
+    / 100,  # Convert value from percent
 )
 
 ureg.add_context(context)

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -4,23 +4,24 @@ import pint
 from pint import Quantity
 from pint.facets.plain import PlainQuantity
 
-ureg = pint.UnitRegistry()
+pnpq_ureg = pint.UnitRegistry()
 
 # Custom unit definitions for MPC320
-ureg.define("mpc320_step = (170 / 1370) degree")
+pnpq_ureg.define("mpc320_step = (170 / 1370) degree")
 
 # According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
 # The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
 # Thus, the unit for mpc_velocity will be set as dimensionless.
 # A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
-ureg.define("mpc320_velocity = []")
+pnpq_ureg.define("mpc320_velocity = []")
 
 context = pint.Context("mpc320_proportional_velocity")
 
-mpc320_max_velocity: Quantity = cast(Quantity, 400 * (ureg.degree / ureg.second))
+mpc320_max_velocity: Quantity = cast(
+    Quantity, 400 * (pnpq_ureg.degree / pnpq_ureg.second)
+)
 
 
-# pylint: disable=W0621
 def to_mpc320_velocity(
     ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
 ) -> PlainQuantity[Quantity]:
@@ -57,5 +58,5 @@ context.add_transformation(
     / 100,  # Convert value from percent
 )
 
-ureg.add_context(context)
-ureg.enable_contexts("mpc320_proportional_velocity")
+pnpq_ureg.add_context(context)
+pnpq_ureg.enable_contexts("mpc320_proportional_velocity")

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -2,5 +2,27 @@ import pint
 
 ureg = pint.UnitRegistry()
 
-# Custom unit definitions
-ureg.define("mpc320_step = (170 / 1370) degree")  # MPC320
+# Initialize the UnitRegistry
+ureg = pint.UnitRegistry()
+
+# Custom unit definitions for MPC320
+ureg.define("mpc320_step = (170 / 1370) degree")
+ureg.define("mpc320_max_velocity = 400 degree / second")
+ureg.define("mpc320_velocity = []")
+
+context = pint.Context("mpc320_proportional_velocity")
+
+context.add_transformation(
+    "degree / second",
+    "mpc320_velocity",
+    lambda ureg, value, **kwargs: value / ureg.mpc320_max_velocity * 100,
+)
+
+context.add_transformation(
+    "mpc320_velocity",
+    "degree / second",
+    lambda ureg, value, **kwargs: value * ureg.mpc320_max_velocity / 100,
+)
+
+ureg.add_context(context)
+ureg.enable_contexts("mpc320_proportional_velocity")

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -1,13 +1,11 @@
 import pint
+from pint import Quantity
+from typing import cast
 
-ureg = pint.UnitRegistry()
-
-# Initialize the UnitRegistry
 ureg = pint.UnitRegistry()
 
 # Custom unit definitions for MPC320
 ureg.define("mpc320_step = (170 / 1370) degree")
-ureg.define("mpc320_max_velocity = 400 degree / second")
 
 # According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
 # The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
@@ -18,16 +16,19 @@ ureg.define("mpc320_velocity = []")
 
 context = pint.Context("mpc320_proportional_velocity")
 
+mpc320_max_velocity = 400 * (ureg.degree / ureg.second)
+
+
 context.add_transformation(
     "degree / second",
     "mpc320_velocity",
-    lambda ureg, value, **kwargs: value / ureg.mpc320_max_velocity * 100,
+    lambda ureg, value, **kwargs: (value / mpc320_max_velocity) * 100, # Convert value to percent
 )
 
 context.add_transformation(
     "mpc320_velocity",
     "degree / second",
-    lambda ureg, value, **kwargs: value * ureg.mpc320_max_velocity / 100,
+    lambda ureg, value, **kwargs: (value * mpc320_max_velocity) / 100, # Convert value from percent
 )
 
 ureg.add_context(context)

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -40,7 +40,7 @@ from pnpq.apt.protocol import (
     Status,
     StopMode,
 )
-from pnpq.units import ureg
+from pnpq.units import pnpq_ureg
 
 
 def test_AptMessage_MGMSG_HW_DISCONNECT_from_bytes() -> None:
@@ -314,7 +314,7 @@ def test_AptMessage_MGMSG_MOT_GET_USTATUSUPDATE_from_bytes() -> None:
     assert msg.source == 0x22
     assert msg.position == 16777216
     assert msg.velocity == 256
-    assert msg.motor_current == -1 * ureg.milliamp
+    assert msg.motor_current == -1 * pnpq_ureg.milliamp
     assert msg.status == Status(CWHARDLIMIT=True, CCWHARDLIMIT=True, CWSOFTLIMIT=True)
 
 
@@ -325,7 +325,7 @@ def test_AptMessage_MGMSG_MOT_GET_USTATUSUPDATE_to_bytes() -> None:
         chan_ident=ChanIdent.CHANNEL_1,
         position=1,
         velocity=1,
-        motor_current=(-1 * ureg.milliamp),
+        motor_current=(-1 * pnpq_ureg.milliamp),
         status=Status(CWHARDLIMIT=True, CCWHARDLIMIT=True, CWSOFTLIMIT=True),
     )
     assert msg.to_bytes() == bytes.fromhex(
@@ -341,7 +341,7 @@ def test_AptMessage_MGMSG_MOT_GET_USTATUSUPDATE_invalid_unit() -> None:
             chan_ident=ChanIdent.CHANNEL_1,
             position=1,
             velocity=1,
-            motor_current=(-1 * ureg.meter),
+            motor_current=(-1 * pnpq_ureg.meter),
             status=Status(CWHARDLIMIT=True, CCWHARDLIMIT=True, CWSOFTLIMIT=True),
         )
 

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -1,4 +1,3 @@
-import pint
 import pytest
 
 from pnpq.units import ureg

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -3,39 +3,57 @@ import pytest
 from pnpq.units import ureg
 
 
-def test_mpc320_step_conversion() -> None:
+@pytest.mark.parametrize(
+    "test_mpc320_step, expected_angle",
+    [
+        (-100, -100 * (170 / 1370)),
+        (0, 0),
+        (100, 100 * (170 / 1370)),
+    ],
+)
+def test_mpc320_step_to_angle_conversion(
+    test_mpc320_step: float, expected_angle: float
+) -> None:
 
-    for value in [-100, 0, 100]:  # Test few values
-
-        pint_degree = (value * ureg.mpc320_step).to("degrees").magnitude
-        decimal_degree = value * (170 / 1370)
-
-        assert pint_degree == pytest.approx(decimal_degree)
-
-        pint_mpc320_step = (value * ureg.degree).to("mpc320_step").magnitude
-        decimal_mpc_320_step = value / (170 / 1370)
-
-        assert pint_mpc320_step == pytest.approx(decimal_mpc_320_step)
+    angle = (test_mpc320_step * ureg.mpc320_step).to("degrees").magnitude
+    assert angle == pytest.approx(expected_angle)
 
 
-def test_mpc320_velocity_conversion() -> None:
+@pytest.mark.parametrize(
+    "test_angle, expected_mpc320_step",
+    [
+        (-100, -100 / (170 / 1370)),
+        (0, 0),
+        (100, 100 / (170 / 1370)),
+    ],
+)
+def test_angle_to_mpc320_step_conversion(
+    test_angle: float, expected_mpc320_step: float
+) -> None:
 
-    velocity = 200 * ureg("degree / second")
+    mpc320_step = (test_angle * ureg.degree).to("mpc320_step").magnitude
+    assert mpc320_step == pytest.approx(expected_mpc320_step)
+
+
+@pytest.mark.parametrize(
+    "deg_per_sec_velocity, mpc320_velocity",
+    [
+        (200, 50),
+        (300, 75),
+    ],
+)
+def test_mpc320_velocity_conversion(
+    deg_per_sec_velocity: float, mpc320_velocity: float
+) -> None:
+
+    # Test that degrees / second quantities accurately convert into mpc320_velocity quantities
+    velocity = deg_per_sec_velocity * ureg("degree / second")
     proportion = velocity.to("mpc320_velocity")
-    assert 50 == pytest.approx(proportion.magnitude)
+    assert mpc320_velocity == pytest.approx(proportion.magnitude)
     assert "mpc320_velocity" == proportion.units
 
-    proportion = 50 * ureg.mpc320_velocity
+    # Test that mpc320_velocity quantities accurately convert back into degrees / second quantities
+    proportion = mpc320_velocity * ureg.mpc320_velocity
     velocity = proportion.to("degree / second")
-    assert 200 == pytest.approx(velocity.magnitude)
-    assert "degree / second" == velocity.units
-
-    velocity = 300 * ureg("degree / second")
-    proportion = velocity.to("mpc320_velocity")
-    assert 75 == pytest.approx(proportion.magnitude)
-    assert "mpc320_velocity" == proportion.units
-
-    proportion = 75 * ureg.mpc320_velocity
-    velocity = proportion.to("degree / second")
-    assert 300 == pytest.approx(velocity.magnitude)
+    assert deg_per_sec_velocity == pytest.approx(velocity.magnitude)
     assert "degree / second" == velocity.units

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -1,0 +1,39 @@
+import pint
+import pytest
+
+from pnpq.units import ureg
+
+
+@pytest.fixture(name="custom_ureg")
+def ureg_fixture() -> pint.UnitRegistry:
+    return ureg
+
+
+def test_mpc320_step_conversion(custom_ureg: pint.UnitRegistry) -> None:
+
+    for value in [-100, 0, 100]:  # Test few values
+
+        pint_degree = (value * custom_ureg.mpc320_step).to("degrees").magnitude
+        decimal_degree = value * (170 / 1370)
+
+        assert pint_degree == pytest.approx(decimal_degree)
+
+        pint_mpc320_step = (value * custom_ureg.degree).to("mpc320_step").magnitude
+        decimal_mpc_320_step = value / (170 / 1370)
+
+        assert pint_mpc320_step == pytest.approx(decimal_mpc_320_step)
+
+
+def test_mpc320_velocity_conversion(custom_ureg: pint.UnitRegistry) -> None:
+
+    velocity = 200 * custom_ureg("degree / second")
+    assert 50 == pytest.approx(velocity.to("mpc320_velocity").magnitude)
+
+    proportion = 50 * custom_ureg.mpc320_velocity
+    assert 200 == pytest.approx(proportion.to("degree / second").magnitude)
+
+    velocity = 300 * custom_ureg("degree / second")
+    assert 75 == pytest.approx(velocity.to("mpc320_velocity").magnitude)
+
+    proportion = 75 * custom_ureg.mpc320_velocity
+    assert 300 == pytest.approx(proportion.to("degree / second").magnitude)

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -1,8 +1,9 @@
+from math import pi
+
 import pytest
+from pint import Quantity
 
 from pnpq.units import ureg
-from pint import Quantity
-from math import pi
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -1,5 +1,3 @@
-from math import pi
-
 import pytest
 from pint import Quantity
 
@@ -9,9 +7,9 @@ from pnpq.units import pnpq_ureg
 @pytest.mark.parametrize(
     "test_mpc320_step, expected_angle",
     [
-        (-100, -100 * (170 / 1370)),
+        (-1370, -170),
         (0, 0),
-        (100, 100 * (170 / 1370)),
+        (1370, 170),
     ],
 )
 def test_mpc320_step_to_angle_conversion(
@@ -25,9 +23,9 @@ def test_mpc320_step_to_angle_conversion(
 @pytest.mark.parametrize(
     "test_angle, expected_mpc320_step",
     [
-        (-100, -100 / (170 / 1370)),
+        (-170, -1370),
         (0, 0),
-        (100, 100 / (170 / 1370)),
+        (170, 1370),
     ],
 )
 def test_angle_to_mpc320_step_conversion(
@@ -40,58 +38,58 @@ def test_angle_to_mpc320_step_conversion(
 
 # Test that [angle] / second quantities accurately convert into mpc320_velocity quantities
 @pytest.mark.parametrize(
-    "angular_velocity, unit, mpc320_velocity",
+    "angular_velocity, mpc320_velocity",
     [
-        (200, pnpq_ureg("degree / second"), 50),
-        (300, pnpq_ureg("degree / second"), 75),
-        (201, pnpq_ureg("degree / second"), 50),
-        (299, pnpq_ureg("degree / second"), 75),
-        (200 * (pi / 180), pnpq_ureg("radian / second"), 50),
-        (300 * (pi / 180), pnpq_ureg("radian / second"), 75),
-        (201 * (pi / 180), pnpq_ureg("radian / second"), 50),
-        (299 * (pi / 180), pnpq_ureg("radian / second"), 75),
-        (200 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 50),
-        (300 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 75),
+        (200 * pnpq_ureg("degree / second"), 50),
+        (300 * pnpq_ureg("degree / second"), 75),
+        (201 * pnpq_ureg("degree / second"), 50),
+        (299 * pnpq_ureg("degree / second"), 75),
+        (3.49065850399 * pnpq_ureg("radian / second"), 50),
+        (5.23598775598 * pnpq_ureg("radian / second"), 75),
+        (3.50811179651 * pnpq_ureg("radian / second"), 50),
+        (5.21853446346 * pnpq_ureg("radian / second"), 75),
+        (1611.76470588 * pnpq_ureg("mpc320_step / second"), 50),
+        (2417.64705882 * pnpq_ureg("mpc320_step / second"), 75),
     ],
 )
 def test_to_mpc320_velocity_conversion(
-    angular_velocity: float, unit: Quantity, mpc320_velocity: float
+    angular_velocity: Quantity, mpc320_velocity: float
 ) -> None:
 
-    velocity = angular_velocity * unit
-    proportion = velocity.to("mpc320_velocity")
-    assert mpc320_velocity == pytest.approx(proportion.magnitude)
+    proportion = angular_velocity.to("mpc320_velocity")
+    assert mpc320_velocity == proportion.magnitude
     assert "mpc320_velocity" == proportion.units
 
 
 # Test that mpc320_velocity quantities accurately convert back into [angle] / second quantities
 @pytest.mark.parametrize(
-    "angular_velocity, unit, mpc320_velocity",
+    "mpc320_velocity, angular_velocity",
     [
-        (200, pnpq_ureg("degree / second"), 50),
-        (300, pnpq_ureg("degree / second"), 75),
-        (200 * (pi / 180), pnpq_ureg("radian / second"), 50),
-        (300 * (pi / 180), pnpq_ureg("radian / second"), 75),
-        (200 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 50),
-        (300 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 75),
+        (50, 200 * pnpq_ureg("degree / second")),
+        (75, 300 * pnpq_ureg("degree / second")),
+        (50, 3.49065850399 * pnpq_ureg("radian / second")),
+        (75, 5.23598775598 * pnpq_ureg("radian / second")),
+        (50, 1611.76470588 * pnpq_ureg("mpc320_step / second")),
+        (75, 2417.64705882 * pnpq_ureg("mpc320_step / second")),
     ],
 )
 def test_from_mpc320_velocity_conversion(
-    angular_velocity: float, unit: Quantity, mpc320_velocity: float
+    mpc320_velocity: float, angular_velocity: Quantity
 ) -> None:
 
     proportion = mpc320_velocity * pnpq_ureg.mpc320_velocity
-    velocity = proportion.to(unit)
-    assert angular_velocity == pytest.approx(velocity.magnitude)
-    assert unit.units == velocity.units
+    velocity = proportion.to(angular_velocity.units)
+    assert angular_velocity.magnitude == pytest.approx(velocity.magnitude)
+    assert angular_velocity.units == velocity.units
 
 
-def test_to_mpc320_velocity_out_of_bounds() -> None:
-
+@pytest.mark.parametrize(
+    "velocity",
+    [
+        5 * (pnpq_ureg.degree / pnpq_ureg.second),  # Too low
+        450 * (pnpq_ureg.degree / pnpq_ureg.second),  # Too high
+    ],
+)
+def test_to_mpc320_velocity_out_of_bounds(velocity: Quantity) -> None:
     with pytest.raises(ValueError, match="Rounded mpc320_velocity .* is out of range"):
-        velocity = 5 * (pnpq_ureg.degree / pnpq_ureg.second)  # Too low
-        velocity.to(pnpq_ureg.mpc320_velocity)
-
-    with pytest.raises(ValueError, match="Rounded mpc320_velocity .* is out of range"):
-        velocity = 450 * (pnpq_ureg.degree / pnpq_ureg.second)  # Too high
         velocity.to(pnpq_ureg.mpc320_velocity)

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -3,7 +3,7 @@ from math import pi
 import pytest
 from pint import Quantity
 
-from pnpq.units import ureg
+from pnpq.units import pnpq_ureg
 
 
 @pytest.mark.parametrize(
@@ -18,7 +18,7 @@ def test_mpc320_step_to_angle_conversion(
     test_mpc320_step: float, expected_angle: float
 ) -> None:
 
-    angle = (test_mpc320_step * ureg.mpc320_step).to("degrees").magnitude
+    angle = (test_mpc320_step * pnpq_ureg.mpc320_step).to("degrees").magnitude
     assert angle == pytest.approx(expected_angle)
 
 
@@ -34,7 +34,7 @@ def test_angle_to_mpc320_step_conversion(
     test_angle: float, expected_mpc320_step: float
 ) -> None:
 
-    mpc320_step = (test_angle * ureg.degree).to("mpc320_step").magnitude
+    mpc320_step = (test_angle * pnpq_ureg.degree).to("mpc320_step").magnitude
     assert mpc320_step == pytest.approx(expected_mpc320_step)
 
 
@@ -42,16 +42,16 @@ def test_angle_to_mpc320_step_conversion(
 @pytest.mark.parametrize(
     "angular_velocity, unit, mpc320_velocity",
     [
-        (200, ureg("degree / second"), 50),
-        (300, ureg("degree / second"), 75),
-        (201, ureg("degree / second"), 50),
-        (299, ureg("degree / second"), 75),
-        (200 * (pi / 180), ureg("radian / second"), 50),
-        (300 * (pi / 180), ureg("radian / second"), 75),
-        (201 * (pi / 180), ureg("radian / second"), 50),
-        (299 * (pi / 180), ureg("radian / second"), 75),
-        (200 / (170 / 1370), ureg("mpc320_step / second"), 50),
-        (300 / (170 / 1370), ureg("mpc320_step / second"), 75),
+        (200, pnpq_ureg("degree / second"), 50),
+        (300, pnpq_ureg("degree / second"), 75),
+        (201, pnpq_ureg("degree / second"), 50),
+        (299, pnpq_ureg("degree / second"), 75),
+        (200 * (pi / 180), pnpq_ureg("radian / second"), 50),
+        (300 * (pi / 180), pnpq_ureg("radian / second"), 75),
+        (201 * (pi / 180), pnpq_ureg("radian / second"), 50),
+        (299 * (pi / 180), pnpq_ureg("radian / second"), 75),
+        (200 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 50),
+        (300 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 75),
     ],
 )
 def test_to_mpc320_velocity_conversion(
@@ -68,19 +68,19 @@ def test_to_mpc320_velocity_conversion(
 @pytest.mark.parametrize(
     "angular_velocity, unit, mpc320_velocity",
     [
-        (200, ureg("degree / second"), 50),
-        (300, ureg("degree / second"), 75),
-        (200 * (pi / 180), ureg("radian / second"), 50),
-        (300 * (pi / 180), ureg("radian / second"), 75),
-        (200 / (170 / 1370), ureg("mpc320_step / second"), 50),
-        (300 / (170 / 1370), ureg("mpc320_step / second"), 75),
+        (200, pnpq_ureg("degree / second"), 50),
+        (300, pnpq_ureg("degree / second"), 75),
+        (200 * (pi / 180), pnpq_ureg("radian / second"), 50),
+        (300 * (pi / 180), pnpq_ureg("radian / second"), 75),
+        (200 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 50),
+        (300 / (170 / 1370), pnpq_ureg("mpc320_step / second"), 75),
     ],
 )
 def test_from_mpc320_velocity_conversion(
     angular_velocity: float, unit: Quantity, mpc320_velocity: float
 ) -> None:
 
-    proportion = mpc320_velocity * ureg.mpc320_velocity
+    proportion = mpc320_velocity * pnpq_ureg.mpc320_velocity
     velocity = proportion.to(unit)
     assert angular_velocity == pytest.approx(velocity.magnitude)
     assert unit.units == velocity.units
@@ -89,9 +89,9 @@ def test_from_mpc320_velocity_conversion(
 def test_to_mpc320_velocity_out_of_bounds() -> None:
 
     with pytest.raises(ValueError, match="Rounded mpc320_velocity .* is out of range"):
-        velocity = 5 * (ureg.degree / ureg.second)  # Too low
-        velocity.to(ureg.mpc320_velocity)
+        velocity = 5 * (pnpq_ureg.degree / pnpq_ureg.second)  # Too low
+        velocity.to(pnpq_ureg.mpc320_velocity)
 
     with pytest.raises(ValueError, match="Rounded mpc320_velocity .* is out of range"):
-        velocity = 450 * (ureg.degree / ureg.second)  # Too high
-        velocity.to(ureg.mpc320_velocity)
+        velocity = 450 * (pnpq_ureg.degree / pnpq_ureg.second)  # Too high
+        velocity.to(pnpq_ureg.mpc320_velocity)

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -4,36 +4,39 @@ import pytest
 from pnpq.units import ureg
 
 
-@pytest.fixture(name="custom_ureg")
-def ureg_fixture() -> pint.UnitRegistry:
-    return ureg
-
-
-def test_mpc320_step_conversion(custom_ureg: pint.UnitRegistry) -> None:
+def test_mpc320_step_conversion() -> None:
 
     for value in [-100, 0, 100]:  # Test few values
 
-        pint_degree = (value * custom_ureg.mpc320_step).to("degrees").magnitude
+        pint_degree = (value * ureg.mpc320_step).to("degrees").magnitude
         decimal_degree = value * (170 / 1370)
 
         assert pint_degree == pytest.approx(decimal_degree)
 
-        pint_mpc320_step = (value * custom_ureg.degree).to("mpc320_step").magnitude
+        pint_mpc320_step = (value * ureg.degree).to("mpc320_step").magnitude
         decimal_mpc_320_step = value / (170 / 1370)
 
         assert pint_mpc320_step == pytest.approx(decimal_mpc_320_step)
 
 
-def test_mpc320_velocity_conversion(custom_ureg: pint.UnitRegistry) -> None:
+def test_mpc320_velocity_conversion() -> None:
 
-    velocity = 200 * custom_ureg("degree / second")
-    assert 50 == pytest.approx(velocity.to("mpc320_velocity").magnitude)
+    velocity = 200 * ureg("degree / second")
+    proportion = velocity.to("mpc320_velocity")
+    assert 50 == pytest.approx(proportion.magnitude)
+    assert "mpc320_velocity" == proportion.units
 
-    proportion = 50 * custom_ureg.mpc320_velocity
-    assert 200 == pytest.approx(proportion.to("degree / second").magnitude)
+    proportion = 50 * ureg.mpc320_velocity
+    velocity = proportion.to("degree / second")
+    assert 200 == pytest.approx(velocity.magnitude)
+    assert "degree / second" == velocity.units
 
-    velocity = 300 * custom_ureg("degree / second")
-    assert 75 == pytest.approx(velocity.to("mpc320_velocity").magnitude)
+    velocity = 300 * ureg("degree / second")
+    proportion = velocity.to("mpc320_velocity")
+    assert 75 == pytest.approx(proportion.magnitude)
+    assert "mpc320_velocity" == proportion.units
 
-    proportion = 75 * custom_ureg.mpc320_velocity
-    assert 300 == pytest.approx(proportion.to("degree / second").magnitude)
+    proportion = 75 * ureg.mpc320_velocity
+    velocity = proportion.to("degree / second")
+    assert 300 == pytest.approx(velocity.magnitude)
+    assert "degree / second" == velocity.units


### PR DESCRIPTION
Closes #76 hopefully.

*  Updated the rest of the parameters of the `PolarizationControllerParams` class (velocity, jog_step_1 2 and 3) to make use of pint's `Quantity` class.
* Updated the test driver code to reflect these new unit updates.
* Implemented a new dimensionless `mpc320_velocity` unit for the `PolarizationControllerParams` velocity field. 
  * In the APT Communications Protocol, it states that the velocity value is a dimensionless percentage value from 10% to 100%, which reflects the proportion of its max speed (400 degrees/sec) to its velocity. In order to support non-dimensionless units (such as degree/second), I have also added a unit transformation tool using pint's `Context` function.
  * Side note: 400 degree/second seems extremely quick, maybe the protocol actually meant 400 steps/second? 
* Also additionally added a new file for unit tests of the pint units (unit-ception!)

The driver tests and the velocity functionality have not been tested on the main device yet, so it may be good to do that before merging with main.

Side note 2: I may have called `black .` which seems to have updated some other files. That is my bad. I am not sure how to revert the changes efficiently. 