### PR TITLE
Mock controller to test mpc320's move_absolute()

### DIFF
--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,0 +1,58 @@
+from typing import Callable
+from unittest.mock import Mock, create_autospec
+
+from pnpq.apt.connection import AptConnection
+from pnpq.apt.protocol import (
+    Address,
+    AptMessage,
+    AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
+    AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
+    ChanIdent,
+    Status,
+    StatusBits,
+)
+from pnpq.devices.polarization_controller_thorlabs_mpc320 import (
+    PolarizationControllerThorlabsMPC320,
+)
+from pnpq.units import pnpq_ureg
+
+
+def test_polarization_controller_move_absolute() -> None:
+
+    connection = create_autospec(AptConnection)
+
+    def mock_send_message_expect_reply(
+        sent_message: AptMessage,
+        match_reply_callback: Callable[
+            [
+                AptMessage,
+            ],
+            bool,
+        ],
+    ) -> None:
+        # Only send a reply if the message is a MOVE_ABSOLUTE message
+        if isinstance(sent_message, AptMessage_MGMSG_MOT_MOVE_ABSOLUTE):
+
+            # A hypothetical reply message from the device
+            reply_message = AptMessage_MGMSG_MOT_GET_USTATUSUPDATE(
+                chan_ident=sent_message.chan_ident,
+                position=sent_message.absolute_distance,
+                velocity=50,
+                motor_current=3 * pnpq_ureg.milliamp,
+                status=Status.from_bits(StatusBits.ACTIVE),
+                destination=Address.HOST_CONTROLLER,
+                source=Address.GENERIC_USB,
+            )
+
+            assert match_reply_callback(reply_message)
+
+    connection.send_message_expect_reply.side_effect = mock_send_message_expect_reply
+    connection.tx_ordered_sender_awaiting_reply = Mock()
+    connection.tx_ordered_sender_awaiting_reply.is_set = Mock(return_value=True)
+
+    controller = PolarizationControllerThorlabsMPC320(connection=connection)
+
+    controller.move_absolute(ChanIdent(1), 10 * pnpq_ureg.mpc320_step)
+
+    # Two calls for enabling and disabling the channel, one call for moving the motor
+    assert connection.send_message_expect_reply.call_count == 3

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -30,7 +30,6 @@ def test_polarization_controller_move_absolute() -> None:
             bool,
         ],
     ) -> None:
-        # Only send a reply if the message is a MOVE_ABSOLUTE message
         if isinstance(sent_message, AptMessage_MGMSG_MOT_MOVE_ABSOLUTE):
 
             # A hypothetical reply message from the device

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -17,7 +17,7 @@ from pnpq.devices.polarization_controller_thorlabs_mpc320 import (
 from pnpq.units import pnpq_ureg
 
 
-def test_polarization_controller_move_absolute() -> None:
+def test_move_absolute() -> None:
 
     connection = create_autospec(AptConnection)
 

--- a/tests/test_polarization_controller_thorlabs_mpc320.py
+++ b/tests/test_polarization_controller_thorlabs_mpc320.py
@@ -32,6 +32,9 @@ def test_move_absolute() -> None:
     ) -> None:
         if isinstance(sent_message, AptMessage_MGMSG_MOT_MOVE_ABSOLUTE):
 
+            assert sent_message.absolute_distance == 10
+            assert sent_message.chan_ident == ChanIdent(1)
+
             # A hypothetical reply message from the device
             reply_message = AptMessage_MGMSG_MOT_GET_USTATUSUPDATE(
                 chan_ident=sent_message.chan_ident,


### PR DESCRIPTION
Closes #74. In theory.

Additions: 
* Created a new test file called `test_mock.py` (is this a good file name?). 
* Uses the `Mock` object from the `unittest` library to mock the behavior of the `AptConnection` class.
* Supports only the `move_absolute` function of the `PolarizationControllerThorlabsMPC320` at the moment.
* Uses the sideeffect functionality to simulate the driver accepting a message, and returning a hypothetical reply. The unit test then checks if whether or not the driver correctly recognizes this hypothetical reply. 
* Asserts that the `AptConnection.send_message_expect_reply()` was correctly called three times. (Two for enabling and disabling the channel, one for the movement itself)

Considerations:
* I would like to assert if the `AptMessage_MGMSG_MOT_MOVE_ABSOLUTE` message was correctly sent while the channel was enabled, but I'm not sure how to do that.
* Defining tests for every single driver function would resulting in having to define a new hypothetical reply message each time. So, this may not be the most efficient way of doing these tests. 