### PR TITLE
Split MOVE_COMPLETED into two separate dataclasses for 6-byte and 20-byte messages.

### DIFF
--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -991,27 +991,41 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessage):
     One for the full 20 byte message, and another for the 6 byte message.
     """
 
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> "AptMessage_MGMSG_MOT_MOVE_COMPLETED":
+        length = len(raw)
+        if length == 6:
+            return AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES.from_bytes(raw)
+        if length == 20:
+            return AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES.from_bytes(raw)
+        raise ValueError(
+            f"Expected data packet length 6 or 20, but received {length} instead. Full raw data was {raw!r}"
+        )
+        pass
+
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES(
-    AptMessage_MGMSG_MOT_MOVE_COMPLETED, AptMessageHeaderOnlyChanIdent
+    AptMessageHeaderOnlyChanIdent, AptMessage_MGMSG_MOT_MOVE_COMPLETED
 ):
     """
     For the MPC320, no data packet follows the main move completed message, so this message is used.
     """
 
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
+    data_length: ClassVar[int] = 0
 
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES(
-    AptMessage_MGMSG_MOT_MOVE_COMPLETED, AptMessageWithDataMotorStatus
+    AptMessageWithDataMotorStatus, AptMessage_MGMSG_MOT_MOVE_COMPLETED
 ):
     """
     For the K10CR1, a full USTATUS data packet follows the main move completed message, so this message is used.
     """
 
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
+    data_length: ClassVar[int] = 14
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -991,6 +991,8 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessage):
     One for the full 20 byte message, and another for the 6 byte message.
     """
 
+    data_length: ClassVar[int]
+
     @classmethod
     def from_bytes(cls, raw: bytes) -> "AptMessage_MGMSG_MOT_MOVE_COMPLETED":
         length = len(raw)
@@ -1001,7 +1003,6 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessage):
         raise ValueError(
             f"Expected data packet length 6 or 20, but received {length} instead. Full raw data was {raw!r}"
         )
-        pass
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1015,6 +1016,10 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES(
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
     data_length: ClassVar[int] = 0
 
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        return super().from_bytes(raw)
+
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES(
@@ -1026,6 +1031,10 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES(
 
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
     data_length: ClassVar[int] = 14
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        return super().from_bytes(raw)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -991,8 +991,6 @@ class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessage):
     One for the full 20 byte message, and another for the 6 byte message.
     """
 
-    pass  # pylint: disable=W0107
-
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES(

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -984,10 +984,34 @@ class AptMessage_MGMSG_MOT_MOVE_ABSOLUTE(AptMessageWithData):
 
 
 @dataclass(frozen=True, kw_only=True)
-class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessageHeaderOnlyChanIdent):
-    """Note that the APT documentation indicates that this should be
-    followed by a full USTATUS data packet. In reality, for the
-    MPC320, no data packet follows."""
+class AptMessage_MGMSG_MOT_MOVE_COMPLETED(AptMessage):
+    """
+    Note that the APT documentation indicates that this should be
+    followed by a full USTATUS data packet. So, two separate methods will be defined.
+    One for the full 20 byte message, and another for the 6 byte message.
+    """
+
+    pass  # pylint: disable=W0107
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES(
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED, AptMessageHeaderOnlyChanIdent
+):
+    """
+    For the MPC320, no data packet follows the main move completed message, so this message is used.
+    """
+
+    message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES(
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED, AptMessageWithDataMotorStatus
+):
+    """
+    For the K10CR1, a full USTATUS data packet follows the main move completed message, so this message is used.
+    """
 
     message_id: ClassVar[AptMessageId] = AptMessageId.MGMSG_MOT_MOVE_COMPLETED
 

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -14,7 +14,7 @@ from ..apt.protocol import (
     AptMessage_MGMSG_MOT_ACK_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
-    AptMessage_MGMSG_MOT_MOVE_COMPLETED,
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES,
     AptMessage_MGMSG_MOT_MOVE_HOME,
     AptMessage_MGMSG_MOT_MOVE_HOMED,
     AptMessage_MGMSG_MOT_MOVE_JOG,
@@ -154,7 +154,7 @@ class PolarizationControllerThorlabsMPC:
                 source=Address.HOST_CONTROLLER,
             ),
             lambda message: (
-                isinstance(message, AptMessage_MGMSG_MOT_MOVE_COMPLETED)
+                isinstance(message, AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES)
                 and message.chan_ident == chan_ident
                 and message.destination == Address.HOST_CONTROLLER
                 and message.source == Address.GENERIC_USB

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -445,7 +445,7 @@ def test_AptMessage_MGMSG_MOT_MOVE_ABSOLUTE_to_bytes() -> None:
     ],
 )
 def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_from_bytes(
-    message_bytes: str, expected_length: int, expected_type: AptMessage
+    message_bytes: str, expected_length: int, expected_type: type[AptMessage]
 ) -> None:
     msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED.from_bytes(bytes.fromhex(message_bytes))
     assert (

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -18,7 +18,8 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_GET_STATUSUPDATE,
     AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
-    AptMessage_MGMSG_MOT_MOVE_COMPLETED,
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES,
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
     AptMessage_MGMSG_MOT_MOVE_HOME,
     AptMessage_MGMSG_MOT_MOVE_HOMED,
     AptMessage_MGMSG_MOT_MOVE_JOG,
@@ -430,8 +431,8 @@ def test_AptMessage_MGMSG_MOT_MOVE_ABSOLUTE_to_bytes() -> None:
     assert msg.to_bytes() == bytes.fromhex("5304 0600 A2 01 0100 400D0300")
 
 
-def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_from_bytes() -> None:
-    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED.from_bytes(
+def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES.from_bytes(
         bytes.fromhex("6404 0100 01 22")
     )
     assert msg.destination == 0x01
@@ -440,13 +441,43 @@ def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_from_bytes() -> None:
     assert msg.chan_ident == 0x01
 
 
-def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_to_bytes() -> None:
-    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED(
+def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES(
         destination=Address.HOST_CONTROLLER,
         source=Address.BAY_1,
         chan_ident=ChanIdent.CHANNEL_1,
     )
     assert msg.to_bytes() == bytes.fromhex("6404 0100 01 22")
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES.from_bytes(
+        # Example message from testing with a real K10CR1 waveplate. Not seen on official documentation.
+        bytes.fromhex("6404 0e00 81 50 0100 68aaa001 0000 0000 30000080")
+    )
+    assert msg.message_id == 0x0464
+    assert msg.chan_ident == 0x01
+    assert msg.destination == 0x01
+    assert msg.source == 0x50
+    assert msg.position == 0x01A0AA68
+    assert msg.velocity == 0x00
+    assert msg.motor_current == 0x00
+    assert msg.status == UStatus(INMOTIONCCW=True, INMOTIONCW=True, ENABLED=True)
+
+
+def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.HOST_CONTROLLER,
+        source=Address.GENERIC_USB,
+        position=0x01A0AA68,
+        velocity=0x00,
+        motor_current=pnpq_ureg.milliamp * 0,
+        status=UStatus(INMOTIONCCW=True, INMOTIONCW=True, ENABLED=True),
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "6404 0e00 81 50 0100 68aaa001 0000 0000 30000080"
+    )
 
 
 def test_AptMessage_MGMSG_MOT_MOVE_HOME_from_bytes() -> None:

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -4,6 +4,7 @@ from pint import DimensionalityError
 
 from pnpq.apt.protocol import (
     Address,
+    AptMessage,
     AptMessage_MGMSG_HW_DISCONNECT,
     AptMessage_MGMSG_HW_GET_INFO,
     AptMessage_MGMSG_HW_REQ_INFO,
@@ -18,6 +19,7 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_GET_STATUSUPDATE,
     AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
+    AptMessage_MGMSG_MOT_MOVE_COMPLETED,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
     AptMessage_MGMSG_MOT_MOVE_HOME,
@@ -429,6 +431,27 @@ def test_AptMessage_MGMSG_MOT_MOVE_ABSOLUTE_to_bytes() -> None:
         absolute_distance=200000,
     )
     assert msg.to_bytes() == bytes.fromhex("5304 0600 A2 01 0100 400D0300")
+
+
+@pytest.mark.parametrize(
+    "message_bytes, expected_length, expected_type",
+    [
+        ("6404 0100 01 22", 6, AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES),
+        (
+            "6404 0e00 81 50 0100 68aaa001 0000 0000 30000080",
+            20,
+            AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
+        ),
+    ],
+)
+def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_from_bytes(
+    message_bytes: str, expected_length: int, expected_type: AptMessage
+) -> None:
+    msg = AptMessage_MGMSG_MOT_MOVE_COMPLETED.from_bytes(bytes.fromhex(message_bytes))
+    assert (
+        msg.data_length + 6 == expected_length
+    )  # 6 bytes for the header which is not included in data_length
+    assert isinstance(msg, expected_type)
 
 
 def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES_from_bytes() -> None:

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -472,7 +472,7 @@ def test_AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES_to_bytes() -> None:
         source=Address.GENERIC_USB,
         position=0x01A0AA68,
         velocity=0x00,
-        motor_current=pnpq_ureg.milliamp * 0,
+        motor_current=0 * pnpq_ureg.milliamp,
         status=UStatus(INMOTIONCCW=True, INMOTIONCW=True, ENABLED=True),
     )
     assert msg.to_bytes() == bytes.fromhex(


### PR DESCRIPTION
I have been pulling my hair out on trying to find an elegant way of separating the dataclasses, and I think I found an alright solution.

Additions:
* Added two new classes `AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES` and `AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES` that inherit from a main `AptMessage_MGMSG_MOT_MOVE_COMPLETED` class. These reflect the two different possibilities of `MOVE_COMPLETED`  messages for the Thorlabs devices. One type contains only 6 header bytes, while the other type contains 6 bytes with an additional 14 data bytes. This can be seen on p.125 of the APT Communications Protocol.
* Added their respective unit tests. 
* Updated the existing MPC320 driver to use this new dataclass.

Considerations:
* As far as we know, the MPC320 prefers the 6 byte message, while the K10CR1 prefers the 20 byte message. However, we are still unsure of what future devices will prefer, so I have left the names ambiguous for that reason. But, the current names are kind of dumb, so if you have any better suggestions I will be grateful.

Resources:
* [APT Communications Protocol](https://www.thorlabs.com/Software/Motion%20Control/APT_Communications_Protocol.pdf).