### PR TITLE
Adds get_status

### DIFF
--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -103,12 +103,12 @@ class PolarizationControllerThorlabsMPC:
                     # should decrease this interval.
                     self.connection.tx_ordered_sender_awaiting_reply.wait(1)
 
-    def get_status_all(self) -> list[AptMessage_MGMSG_MOT_GET_USTATUSUPDATE]:
+    def get_status_all(self) -> tuple[AptMessage_MGMSG_MOT_GET_USTATUSUPDATE, ...]:
         all_status = []
         for channel in self.available_channels:
             status = self.get_status(channel)
             all_status.append(status)
-        return all_status
+        return tuple(all_status)
 
     def get_status(
         self, chan_ident: ChanIdent

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -103,7 +103,16 @@ class PolarizationControllerThorlabsMPC:
                     # should decrease this interval.
                     self.connection.tx_ordered_sender_awaiting_reply.wait(1)
 
-    def get_status(self, chan_ident: ChanIdent) -> AptMessage_MGMSG_MOT_GET_USTATUSUPDATE:
+    def get_status_all(self) -> list[AptMessage_MGMSG_MOT_GET_USTATUSUPDATE]:
+        all_status = []
+        for channel in self.available_channels:
+            status = self.get_status(channel)
+            all_status.append(status)
+        return all_status
+
+    def get_status(
+        self, chan_ident: ChanIdent
+    ) -> AptMessage_MGMSG_MOT_GET_USTATUSUPDATE:
         msg = self.connection.send_message_expect_reply(
             AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE(
                 chan_ident=chan_ident,
@@ -115,7 +124,7 @@ class PolarizationControllerThorlabsMPC:
                 and message.chan_ident == chan_ident
                 and message.destination == Address.HOST_CONTROLLER
                 and message.source == Address.GENERIC_USB
-            )
+            ),
         )
         return cast(AptMessage_MGMSG_MOT_GET_USTATUSUPDATE, msg)
 

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -103,6 +103,22 @@ class PolarizationControllerThorlabsMPC:
                     # should decrease this interval.
                     self.connection.tx_ordered_sender_awaiting_reply.wait(1)
 
+    def get_status(self, chan_ident: ChanIdent) -> AptMessage_MGMSG_MOT_GET_USTATUSUPDATE:
+        msg = self.connection.send_message_expect_reply(
+            AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE(
+                chan_ident=chan_ident,
+                destination=Address.GENERIC_USB,
+                source=Address.HOST_CONTROLLER,
+            ),
+            lambda message: (
+                isinstance(message, AptMessage_MGMSG_MOT_GET_USTATUSUPDATE)
+                and message.chan_ident == chan_ident
+                and message.destination == Address.HOST_CONTROLLER
+                and message.source == Address.GENERIC_USB
+            )
+        )
+        return cast(AptMessage_MGMSG_MOT_GET_USTATUSUPDATE, msg)
+
     def home(self, chan_ident: ChanIdent) -> None:
         self.set_channel_enabled(chan_ident, True)
         start_time = time.perf_counter()


### PR DESCRIPTION
Closes #95 

Implements 2 functions:

- `get_status(self, chan_ident: ChanIdent) -> AptMessage_MGMSG_MOT_GET_USTATUSUPDATE` - Get status for a specified channel
- `get_status_all(self) -> list[AptMessage_MGMSG_MOT_GET_USTATUSUPDATE]` - Get a list of status for all channels