### PR TITLE
Add an initializer to ChanIdent to support initialization from integers

### DIFF
--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -111,6 +111,12 @@ class ChanIdent(IntFlag, boundary=STRICT):
     CHANNEL_3 = 0x04
     CHANNEL_4 = 0x08
 
+    @classmethod
+    def from_linear(cls, linear: int) -> "ChanIdent":
+        if linear < 1 or linear > 4:
+            raise ValueError("Channel identifier must be between 1 and 4.")
+        return cls(1 << (linear - 1))
+
 
 @enum.unique
 class EnableState(int, Enum):

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -710,12 +710,15 @@ def test_AptMessage_MGMSG_MOT_SET_EEPROMPARAMS_to_bytes() -> None:
     assert msg.to_bytes() == bytes.fromhex("B904 0400 D0 01 0100 0600")
 
 
-def test_ChanIdent_init() -> None:
-    chan_1 = ChanIdent.from_linear(1)
-    assert chan_1 == ChanIdent.CHANNEL_1
-    chan_2 = ChanIdent.from_linear(2)
-    assert chan_2 == ChanIdent.CHANNEL_2
-    chan_3 = ChanIdent.from_linear(3)
-    assert chan_3 == ChanIdent.CHANNEL_3
-    chan_4 = ChanIdent.from_linear(4)
-    assert chan_4 == ChanIdent.CHANNEL_4
+@pytest.mark.parametrize(
+    "chan_ident_int, expected_channel",
+    [
+        (1, ChanIdent.CHANNEL_1),
+        (2, ChanIdent.CHANNEL_2),
+        (3, ChanIdent.CHANNEL_3),
+        (4, ChanIdent.CHANNEL_4),
+    ],
+)
+def test_ChanIdent_init(chan_ident_int: int, expected_channel: ChanIdent) -> None:
+    chan_ident = ChanIdent.from_linear(chan_ident_int)
+    assert chan_ident == expected_channel

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -708,3 +708,14 @@ def test_AptMessage_MGMSG_MOT_SET_EEPROMPARAMS_to_bytes() -> None:
         message_id_to_save=AptMessageId.MGMSG_HW_GET_INFO,
     )
     assert msg.to_bytes() == bytes.fromhex("B904 0400 D0 01 0100 0600")
+
+
+def test_ChanIdent_init() -> None:
+    chan_1 = ChanIdent.from_linear(1)
+    assert chan_1 == ChanIdent.CHANNEL_1
+    chan_2 = ChanIdent.from_linear(2)
+    assert chan_2 == ChanIdent.CHANNEL_2
+    chan_3 = ChanIdent.from_linear(3)
+    assert chan_3 == ChanIdent.CHANNEL_3
+    chan_4 = ChanIdent.from_linear(4)
+    assert chan_4 == ChanIdent.CHANNEL_4


### PR DESCRIPTION
This function would come in handy in implementing external libraries where int has to be passed to the initializer of the `ChanIdent` enum. 

In addition, a test was also added: `test_ChanIdent_init`