### PR TITLE
Fix bug that made non-degree type angles be incorrectly converted to mpc320_step 

### DIFF
--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -17,7 +17,9 @@ pnpq_ureg.define("k10cr1_step = [dimension_k10cr1_step]")
 def degree_to_mpc320_steps(
     ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
 ) -> PlainQuantity[Any]:
-    return Quantity(round(value.magnitude * 1370 / 170), ureg.mpc320_step)
+    return Quantity(
+        round((value.to("degree")).magnitude * 1370 / 170), ureg.mpc320_step
+    )
 
 
 def mpc320_steps_to_degree(
@@ -30,7 +32,7 @@ def mpc320_steps_to_degree(
 def degree_to_k10cr1_steps(
     ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
 ) -> PlainQuantity[Any]:
-    return Quantity(round(value.magnitude * 136533 / 1), ureg.k10cr1_step)
+    return Quantity(round(value.to("degree").magnitude * 136533 / 1), ureg.k10cr1_step)
 
 
 def k10cr1_steps_to_degree(
@@ -51,6 +53,10 @@ thorlabs_context.add_transformation("k10cr1_step", "degree", k10cr1_steps_to_deg
 # A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
 pnpq_ureg.define("mpc320_velocity = [dimension_mpc320_velocity]")
 
+# According to the protocol (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
+# and 1 degree/sec^2 to 1502 steps/sec^2 for acceleration
+pnpq_ureg.define("k10cr1_velocity = [dimension_k10cr1_velocity]")
+pnpq_ureg.define("k10cr1_acceleration = [dimension_k10cr1_acceleration]")
 
 mpc320_max_velocity: Quantity = cast(
     Quantity, 400 * (pnpq_ureg.degree / pnpq_ureg.second)
@@ -139,6 +145,7 @@ thorlabs_context.add_transformation(
     "mpc320_velocity",
     mpc320_step_velocity_to_mpc320_velocity,
 )
+
 
 # Add and enable the context
 pnpq_ureg.add_context(thorlabs_context)

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -146,7 +146,6 @@ thorlabs_context.add_transformation(
     mpc320_step_velocity_to_mpc320_velocity,
 )
 
-
 # Add and enable the context
 pnpq_ureg.add_context(thorlabs_context)
 pnpq_ureg.enable_contexts("thorlabs_context")

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -5,69 +5,79 @@ from pnpq.units import pnpq_ureg
 
 
 @pytest.mark.parametrize(
-    "test_mpc320_step, expected_angle",
+    "test_mpc320_step, expected_angle, output_units",
     [
-        (-1370, -170),
-        (0, 0),
-        (1370, 170),
+        (-1370, -170, "degree"),
+        (0, 0, "degree"),
+        (1370, 170, "degree"),
+        (1370, 2.96706, "radians"),
     ],
 )
 def test_mpc320_step_to_angle_conversion(
-    test_mpc320_step: float, expected_angle: float
+    test_mpc320_step: float, expected_angle: float, output_units: str
 ) -> None:
 
-    angle = (test_mpc320_step * pnpq_ureg.mpc320_step).to("degrees").magnitude
+    angle = (test_mpc320_step * pnpq_ureg.mpc320_step).to(output_units).magnitude
     assert angle == pytest.approx(expected_angle)
 
 
 @pytest.mark.parametrize(
     "test_angle, expected_mpc320_step",
     [
-        (-170, -1370),
-        (0, 0),
-        (170, 1370),
-        (169, 1362),  # This will be able to test the actual rounding
+        (-170 * pnpq_ureg.degree, -1370),
+        (0 * pnpq_ureg.degree, 0),
+        (170 * pnpq_ureg.degree, 1370),
+        (169 * pnpq_ureg.degree, 1362),  # This will be able to test the actual rounding
+        (90 * pnpq_ureg.degree, 725),
+        (1.570796 * pnpq_ureg.radian, 725),
+        (100 * pnpq_ureg.mpc320_step, 100),
     ],
 )
 def test_angle_to_mpc320_step_conversion(
-    test_angle: float, expected_mpc320_step: int
+    test_angle: Quantity, expected_mpc320_step: int
 ) -> None:
 
-    mpc320_step = (test_angle * pnpq_ureg.degree).to("mpc320_step").magnitude
+    mpc320_step = test_angle.to("mpc320_step").magnitude
     assert mpc320_step == expected_mpc320_step
     assert isinstance(mpc320_step, int)
 
 
 @pytest.mark.parametrize(
-    "test_k10cr1_step, expected_angle",
+    "test_k10cr1_step, expected_angle, output_units",
     [
-        (-136533, -1),
-        (0, 0),
-        (136533, 1),
+        (-136533, -1, "degree"),
+        (0, 0, "degree"),
+        (136533, 1, "degree"),
+        (136533, 0.0174533, "radians"),
     ],
 )
 def test_k10cr1_step_to_angle_conversion(
-    test_k10cr1_step: float, expected_angle: float
+    test_k10cr1_step: Quantity, expected_angle: float, output_units: str
 ) -> None:
 
-    angle = (test_k10cr1_step * pnpq_ureg.k10cr1_step).to("degrees").magnitude
+    angle = (test_k10cr1_step * pnpq_ureg.k10cr1_step).to(output_units).magnitude
     assert angle == pytest.approx(expected_angle)
 
 
 @pytest.mark.parametrize(
     "test_angle, expected_k10cr1_step",
     [
-        (-1, -136533),
-        (0, 0),
-        (1, 136533),
-        (1.000001, 136533),  # This will be able to test the actual rounding
+        (-1 * pnpq_ureg.degree, -136533),
+        (0 * pnpq_ureg.degree, 0),
+        (1 * pnpq_ureg.degree, 136533),
+        (
+            1.000001 * pnpq_ureg.degree,
+            136533,
+        ),  # This will be able to test the actual rounding
+        (0.0174533 * pnpq_ureg.radian, 136533),
+        (100 * pnpq_ureg.k10cr1_step, 100),
     ],
 )
 def test_angle_to_k10cr1_step_conversion(
-    test_angle: float, expected_k10cr1_step: int
+    test_angle: Quantity, expected_k10cr1_step: int
 ) -> None:
 
-    k10cr1_step = (test_angle * pnpq_ureg.degree).to("k10cr1_step").magnitude
+    k10cr1_step = (test_angle).to("k10cr1_step").magnitude
     assert k10cr1_step == expected_k10cr1_step
     assert isinstance(k10cr1_step, int)
 


### PR DESCRIPTION
While messing around with testbed-node last week with Tom, we encountered a strange error in which radians converted to type `mpc320_step` visually resulted in the wrong angle on the device. I was looking through the `units.py` code and found the culprit of this issue.

### Issue

When converting specific angles into `mpc320_step`, we perform the conversion based on the assumption that the input angle is in degrees. However, this may not necessarily be the case. 

### Fix

Therefore, an easy fix is to convert the inputted angle into degrees first, then perform the conversion calculation to `mpc320_step`.

### Additions
I have implemented this quick fix and also updated the unit tests to accordingly test for conversions from non-degree type angles (such as radians).