### PR TITLE
Add K10CR1 mock waveplate and refactor pint units code to use generator

### DIFF
--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -9,6 +9,7 @@ pnpq_ureg = pint.UnitRegistry()
 
 thorlabs_context = pint.Context("thorlabs_context")
 
+
 def get_unit_transformation(
     input_to_output: Callable[[float], float],
     input_unit: pint.Unit,
@@ -38,6 +39,7 @@ def get_unit_transformation(
         return converted_quantity
 
     return to_quantity
+
 
 # Custom unit definitions for devices
 pnpq_ureg.define("mpc320_step = [dimension_mpc320_step]")
@@ -119,8 +121,6 @@ thorlabs_context.add_transformation(
         input_to_output=lambda steps: steps / 100 * 400,
         input_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
         output_unit=cast(Unit, pnpq_ureg("degree / second")),
-        output_range=None,
-        output_rounded=False,
     ),
 )
 
@@ -133,9 +133,7 @@ thorlabs_context.add_transformation(
         input_unit=cast(Unit, pnpq_ureg("degree / second")),
         output_unit=cast(
             Unit, pnpq_ureg("mpc320_step / second")
-        ),  # Already rounded because casted into mpc320_step
-        output_range=None,
-        output_rounded=False,
+        ),  # Already rounded because using degrees / second -> mpc320_velocity conversion
     ),
 )
 
@@ -151,8 +149,6 @@ thorlabs_context.add_transformation(
         .magnitude,
         input_unit=cast(Unit, pnpq_ureg("mpc320_step / second")),
         output_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
-        output_range=None,
-        output_rounded=False,
     ),
 )
 

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -9,48 +9,12 @@ pnpq_ureg = pint.UnitRegistry()
 
 thorlabs_context = pint.Context("thorlabs_context")
 
-# Custom unit definitions for devices
-pnpq_ureg.define("mpc320_step = [dimension_mpc320_step]")
-pnpq_ureg.define("k10cr1_step = [dimension_k10cr1_step]")
-
-
-# Transformation function for converting between k10cr1_step and degrees
-def degree_to_k10cr1_steps(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Any]:
-    return Quantity(round(value.to("degree").magnitude * 136533 / 1), ureg.k10cr1_step)
-
-
-def k10cr1_steps_to_degree(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Any]:
-    return Quantity(value.magnitude * 1 / 136533, ureg.degree)
-
-
-def thorlabs_quantity_to_angle(
-    thorlabs_quantity_to_degrees: Callable[[float], float], output_unit: pint.Unit
-) -> Transformation:
-
-    def to_angle(
-        ureg: pint.UnitRegistry,  # pylint: disable=unused-argument
-        value: PlainQuantity[Quantity],
-        **kwargs: Any,  # pylint: disable=unused-argument
-    ) -> PlainQuantity[Any]:
-        return Quantity(
-            thorlabs_quantity_to_degrees(float(value.magnitude)),
-            output_unit,
-        )
-
-    return to_angle
-
-
-def angle_to_thorlabs_quantity(
+def get_unit_transformation(
     input_to_output: Callable[[float], float],
     input_unit: pint.Unit,
     output_unit: pint.Unit,
-    output_range: None | tuple[float, float],
-    output_rounded: bool = True,
-
+    output_range: None | tuple[float, float] = None,
+    output_rounded: bool = False,
 ) -> Transformation:
 
     def to_quantity(
@@ -75,29 +39,54 @@ def angle_to_thorlabs_quantity(
 
     return to_quantity
 
+# Custom unit definitions for devices
+pnpq_ureg.define("mpc320_step = [dimension_mpc320_step]")
+pnpq_ureg.define("k10cr1_step = [dimension_k10cr1_step]")
 
 thorlabs_context.add_transformation(
     "degree",
     "mpc320_step",
-    angle_to_thorlabs_quantity(
+    get_unit_transformation(
         input_to_output=lambda degrees: degrees * 1370 / 170,
         input_unit=pnpq_ureg.degree,
         output_unit=pnpq_ureg.mpc320_step,
         output_range=None,
+        output_rounded=True,
     ),
 )
 
 thorlabs_context.add_transformation(
     "mpc320_step",
     "degree",
-    thorlabs_quantity_to_angle(
-        thorlabs_quantity_to_degrees=lambda steps: steps * 170 / 1370,
+    get_unit_transformation(
+        input_to_output=lambda steps: steps * 170 / 1370,
+        input_unit=pnpq_ureg.mpc320_step,
         output_unit=pnpq_ureg.degree,
+        output_range=None,
+        output_rounded=False,
     ),
 )
 
-thorlabs_context.add_transformation("degree", "k10cr1_step", degree_to_k10cr1_steps)
-thorlabs_context.add_transformation("k10cr1_step", "degree", k10cr1_steps_to_degree)
+thorlabs_context.add_transformation(
+    "degree",
+    "k10cr1_step",
+    get_unit_transformation(
+        input_to_output=lambda degrees: degrees * 136533,
+        input_unit=pnpq_ureg.degree,
+        output_unit=pnpq_ureg.k10cr1_step,
+        output_rounded=True,
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_step",
+    "degree",
+    get_unit_transformation(
+        input_to_output=lambda steps: steps / 136533,
+        input_unit=pnpq_ureg.k10cr1_step,
+        output_unit=pnpq_ureg.degree,
+    ),
+)
 
 # According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
 # The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
@@ -105,60 +94,20 @@ thorlabs_context.add_transformation("k10cr1_step", "degree", k10cr1_steps_to_deg
 # A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
 pnpq_ureg.define("mpc320_velocity = [dimension_mpc320_velocity]")
 
-# According to the protocol (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
-# and 1 degree/sec^2 to 1502 steps/sec^2 for acceleration
-pnpq_ureg.define("k10cr1_velocity = [dimension_k10cr1_velocity]")
-pnpq_ureg.define("k10cr1_acceleration = [dimension_k10cr1_acceleration]")
-
 mpc320_max_velocity: Quantity = cast(
     Quantity, 400 * (pnpq_ureg.degree / pnpq_ureg.second)
 )
 
 
-def to_mpc320_velocity(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Quantity]:
-    """
-    Converts a given velocity to an mpc320 velocity percentage.
-    Raises a ValueError if the rounded velocity is out of the range [10, 100].
-    """
-    # Ensure velocity is in the same units as max velocity
-
-    velocity_in_degrees: Quantity = cast(Quantity, value.to(mpc320_max_velocity.units))
-
-    converted_velocity = (velocity_in_degrees / mpc320_max_velocity) * 100
-    rounded_velocity: Quantity = (
-        round(converted_velocity.magnitude) * ureg.mpc320_velocity
-    )
-
-    if rounded_velocity.magnitude < 10 or rounded_velocity.magnitude > 100:
-        raise ValueError(
-            f"Rounded mpc320_velocity {rounded_velocity.magnitude} is out of range (10 to 100)."
-        )
-
-    return rounded_velocity
-
-
-def mpc320_velocity_to_pint_velocity(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Quantity]:
-    """
-    Converts an mpc320 velocity percentage to a velocity in degrees per second.
-    """
-    return Quantity(
-        (value.magnitude * mpc320_max_velocity) / 100,
-        cast(Unit, ureg("degree / second")),
-    )
-
-
 thorlabs_context.add_transformation(
     "degree / second",
     "mpc320_velocity",
-    angle_to_thorlabs_quantity(
+    get_unit_transformation(
         input_to_output=lambda degrees: degrees / 400 * 100,
         input_unit=cast(Unit, pnpq_ureg("degree / second")),
         output_unit=pnpq_ureg.mpc320_velocity,
         output_range=(10, 100),
+        output_rounded=True,
     ),
     # to_mpc320_velocity,  # Convert value to percent
 )
@@ -166,53 +115,40 @@ thorlabs_context.add_transformation(
 thorlabs_context.add_transformation(
     "mpc320_velocity",
     "degree / second",
-    thorlabs_quantity_to_angle(
-        thorlabs_quantity_to_degrees=lambda steps: steps / 100 * 400,
-        output_unit=cast(Unit, pnpq_ureg("degree / second")),
-    ),
-)
-
-
-# Add transformations between mpc320_velocity and mpc320_step
-def mpc320_velocity_to_mpc320_step_velocity(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Quantity]:
-    """
-    Converts an mpc320 velocity percentage to a velocity in degrees per second.
-    """
-    degrees_per_second = value.to("degree / second").magnitude
-    steps_per_second = degrees_per_second / 170 * 1370
-    return Quantity(steps_per_second, cast(Unit, ureg("mpc320_step / second")))
-
-
-def mpc320_step_velocity_to_mpc320_velocity(
-    ureg: pint.UnitRegistry, value: PlainQuantity[Quantity], **_: Any
-) -> PlainQuantity[Quantity]:
-    """
-    Converts an mpc320 velocity percentage to a velocity in degrees per second.
-    """
-    degrees_per_second = value.magnitude / 1370 * 170 * ureg("degree / second")
-    new_velocity = degrees_per_second.to("mpc320_velocity")
-    return cast(Quantity, new_velocity)
-
-
-thorlabs_context.add_transformation(
-    "mpc320_velocity",
-    "mpc320_step / second",
-    angle_to_thorlabs_quantity(
-        input_to_output=lambda step: ( (step / 170 * 1370) * pnpq_ureg("degree / second") ),
+    get_unit_transformation(
+        input_to_output=lambda steps: steps / 100 * 400,
         input_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
-        output_unit=cast(Unit, pnpq_ureg("mpc320_step / second")),
+        output_unit=cast(Unit, pnpq_ureg("degree / second")),
         output_range=None,
         output_rounded=False,
     ),
 )
 
+
+thorlabs_context.add_transformation(
+    "mpc320_velocity",
+    "mpc320_step / second",
+    get_unit_transformation(
+        input_to_output=lambda degrees_per_second: degrees_per_second / 170 * 1370,
+        input_unit=cast(Unit, pnpq_ureg("degree / second")),
+        output_unit=cast(
+            Unit, pnpq_ureg("mpc320_step / second")
+        ),  # Already rounded because casted into mpc320_step
+        output_range=None,
+        output_rounded=False,
+    ),
+)
+
+
 thorlabs_context.add_transformation(
     "mpc320_step / second",
     "mpc320_velocity",
-    angle_to_thorlabs_quantity(
-        input_to_output=lambda step: (step * pnpq_ureg("mpc320_step / second")).to("degree / second").magnitude * 170 / 1370,
+    get_unit_transformation(
+        input_to_output=lambda step: (
+            (step / 1370) * 170 * pnpq_ureg("degree / second")
+        )
+        .to("mpc320_velocity")
+        .magnitude,
         input_unit=cast(Unit, pnpq_ureg("mpc320_step / second")),
         output_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
         output_range=None,

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -45,6 +45,21 @@ def get_unit_transformation(
 pnpq_ureg.define("mpc320_step = [dimension_mpc320_step]")
 pnpq_ureg.define("k10cr1_step = [dimension_k10cr1_step]")
 
+# According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
+# The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
+# Thus, the unit for mpc_velocity will be set as dimensionless.
+# A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
+pnpq_ureg.define("mpc320_velocity = [dimension_mpc320_velocity]")
+
+mpc320_max_velocity: Quantity = cast(
+    Quantity, 400 * (pnpq_ureg.degree / pnpq_ureg.second)
+)
+
+# According to the protocol (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
+# and 1 degree/sec^2 to 1502 steps/sec^2 for acceleration
+pnpq_ureg.define("k10cr1_velocity = [dimension_k10cr1_velocity]")
+pnpq_ureg.define("k10cr1_acceleration = [dimension_k10cr1_acceleration]")
+
 thorlabs_context.add_transformation(
     "degree",
     "mpc320_step",
@@ -90,17 +105,6 @@ thorlabs_context.add_transformation(
     ),
 )
 
-# According to the protocol, velocity is expressed as a percentage of the maximum speed, ranging from 10% to 100%.
-# The maximum velocity is defined as 400 degrees per second, so we store velocity as a dimensionless proportion of this value.
-# Thus, the unit for mpc_velocity will be set as dimensionless.
-# A transformation function (defined below) will convert other units, like degrees per second, into this proportional form.
-pnpq_ureg.define("mpc320_velocity = [dimension_mpc320_velocity]")
-
-mpc320_max_velocity: Quantity = cast(
-    Quantity, 400 * (pnpq_ureg.degree / pnpq_ureg.second)
-)
-
-
 thorlabs_context.add_transformation(
     "degree / second",
     "mpc320_velocity",
@@ -124,7 +128,6 @@ thorlabs_context.add_transformation(
     ),
 )
 
-
 thorlabs_context.add_transformation(
     "mpc320_velocity",
     "mpc320_step / second",
@@ -136,7 +139,6 @@ thorlabs_context.add_transformation(
         ),  # Already rounded because using degrees / second -> mpc320_velocity conversion
     ),
 )
-
 
 thorlabs_context.add_transformation(
     "mpc320_step / second",

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -200,8 +200,8 @@ thorlabs_context.add_transformation(
     "mpc320_velocity",
     "mpc320_step / second",
     angle_to_thorlabs_quantity(
-        input_to_output=lambda step: step / 170 * 1370,
-        input_unit=cast(Unit, pnpq_ureg("degree / second")), # Convert input to degree / second and use previously defined function
+        input_to_output=lambda step: ( (step / 170 * 1370) * pnpq_ureg("degree / second") ),
+        input_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
         output_unit=cast(Unit, pnpq_ureg("mpc320_step / second")),
         output_range=None,
         output_rounded=False,
@@ -211,7 +211,13 @@ thorlabs_context.add_transformation(
 thorlabs_context.add_transformation(
     "mpc320_step / second",
     "mpc320_velocity",
-    mpc320_step_velocity_to_mpc320_velocity,
+    angle_to_thorlabs_quantity(
+        input_to_output=lambda step: (step * pnpq_ureg("mpc320_step / second")).to("degree / second").magnitude * 170 / 1370,
+        input_unit=cast(Unit, pnpq_ureg("mpc320_step / second")),
+        output_unit=cast(Unit, pnpq_ureg("mpc320_velocity")),
+        output_range=None,
+        output_rounded=False,
+    ),
 )
 
 # Add and enable the context

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -137,5 +137,8 @@ def test_from_mpc320_velocity_conversion(
     ],
 )
 def test_to_mpc320_velocity_out_of_bounds(velocity: Quantity) -> None:
-    with pytest.raises(ValueError, match="Rounded mpc320_velocity .* is out of range"):
+    with pytest.raises(
+        ValueError,
+        match="Rounded mpc320_velocity [0-9]+ is out of range \\(10, 100\\)\\.",
+    ):
         velocity.to(pnpq_ureg.mpc320_velocity)


### PR DESCRIPTION
Closes #103 

This should have been split into two different pull requests but I worked on them on the same branch, and I'm not sure if it's possible to split it now... So, I'll leave it like this for now. Please forgive me.

## Implementations
* Adds a mock waveplate for the K10CR1 that verifies the `move_absolute` method in the base driver listens for the appropriate message
* Since the `units.py` class was getting a bit repetitive, I tried to encapsulate the repeated code into a function `get_unit_transformation` which generates the appropriate transformation units. 
  * Also has flexibility to allow for complex transformations using a lambda function, as well as the ability to round the output or limit the output to a certain range.
