### PR TITLE
Velocity and acceleration pint units for K10CR1

### DIFF
--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -159,7 +159,7 @@ thorlabs_context.add_transformation(
     "degree / second",
     "k10cr1_velocity",
     get_unit_transformation(
-        input_to_output=lambda degrees: degrees * 7329109,
+        input_to_output=lambda degrees_per_second: degrees_per_second * 7329109,
         input_unit=cast(Unit, pnpq_ureg("degree / second")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
         output_rounded=True,
@@ -170,7 +170,7 @@ thorlabs_context.add_transformation(
     "k10cr1_velocity",
     "degree / second",
     get_unit_transformation(
-        input_to_output=lambda steps: steps / 7329109,
+        input_to_output=lambda velocity: velocity / 7329109,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
         output_unit=cast(Unit, pnpq_ureg("degree / second")),
     ),
@@ -180,10 +180,10 @@ thorlabs_context.add_transformation(
     "k10cr1_velocity",
     "k10cr1_step / second",
     get_unit_transformation(
-        input_to_output=lambda degrees_per_second: (degrees_per_second * 136533)
-        / 7329109,
+        input_to_output=lambda velocity: (velocity * 136533) / 7329109,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
+        output_rounded=True,
     ),
 )
 
@@ -191,7 +191,7 @@ thorlabs_context.add_transformation(
     "k10cr1_step / second",
     "k10cr1_velocity",
     get_unit_transformation(
-        input_to_output=lambda step_per_second: (step_per_second / 136533) * 7329109,
+        input_to_output=lambda steps_per_second: (steps_per_second / 136533) * 7329109,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
         output_rounded=True,
@@ -203,7 +203,7 @@ thorlabs_context.add_transformation(
     "degree / second ** 2",
     "k10cr1_acceleration",
     get_unit_transformation(
-        input_to_output=lambda degrees: degrees * 1502,
+        input_to_output=lambda degrees_per_sec_squared: degrees_per_sec_squared * 1502,
         input_unit=cast(Unit, pnpq_ureg("degree / second ** 2")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
         output_rounded=True,
@@ -214,7 +214,7 @@ thorlabs_context.add_transformation(
     "k10cr1_acceleration",
     "degree / second ** 2",
     get_unit_transformation(
-        input_to_output=lambda steps: steps / 1502,
+        input_to_output=lambda acceleration: acceleration / 1502,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
         output_unit=cast(Unit, pnpq_ureg("degree / second ** 2")),
     ),
@@ -237,10 +237,10 @@ thorlabs_context.add_transformation(
     "k10cr1_acceleration",
     "k10cr1_step / second ** 2",
     get_unit_transformation(
-        input_to_output=lambda k10cr1_acceleration: (k10cr1_acceleration / 1502)
-        * 136533,
+        input_to_output=lambda acceleration: (acceleration / 1502) * 136533,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second ** 2")),
+        output_rounded=True,
     ),
 )
 

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -154,6 +154,99 @@ thorlabs_context.add_transformation(
     ),
 )
 
+# Add K10CR1 velocity transformations
+thorlabs_context.add_transformation(
+    "degree / second",
+    "k10cr1_velocity",
+    get_unit_transformation(
+        input_to_output=lambda degrees: degrees * 7329109,
+        input_unit=cast(Unit, pnpq_ureg("degree / second")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
+        output_rounded=True,
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_velocity",
+    "degree / second",
+    get_unit_transformation(
+        input_to_output=lambda steps: steps / 7329109,
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
+        output_unit=cast(Unit, pnpq_ureg("degree / second")),
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_velocity",
+    "k10cr1_step / second",
+    get_unit_transformation(
+        input_to_output=lambda degrees_per_second: degrees_per_second * 136533,
+        input_unit=cast(Unit, pnpq_ureg("degree / second")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_step / second",
+    "k10cr1_velocity",
+    get_unit_transformation(
+        input_to_output=lambda step_per_second: (
+            step_per_second / 136533 * pnpq_ureg("degree / second")
+        )
+        .to("k10cr1_velocity")
+        .magnitude,
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
+    ),
+)
+
+# Add accleleration transformations
+thorlabs_context.add_transformation(
+    "degree / second ** 2",
+    "k10cr1_acceleration",
+    get_unit_transformation(
+        input_to_output=lambda degrees: degrees * 1502,
+        input_unit=cast(Unit, pnpq_ureg("degree / second ** 2")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
+        output_rounded=True,
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_acceleration",
+    "degree / second ** 2",
+    get_unit_transformation(
+        input_to_output=lambda steps: steps / 1502,
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
+        output_unit=cast(Unit, pnpq_ureg("degree / second ** 2")),
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_step / second ** 2",
+    "k10cr1_acceleration",
+    get_unit_transformation(
+        input_to_output=lambda steps_per_sec_squared: (
+            steps_per_sec_squared / 136533 * pnpq_ureg("degree / second ** 2")
+        )
+        .to("k10cr1_acceleration")
+        .magnitude,
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_step / second ** 2")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
+    ),
+)
+
+thorlabs_context.add_transformation(
+    "k10cr1_acceleration",
+    "k10cr1_step / second ** 2",
+    get_unit_transformation(
+        input_to_output=lambda degrees_per_sec_squared: degrees_per_sec_squared
+        * 136533,
+        input_unit=cast(Unit, pnpq_ureg("degrees / second ** 2")),
+        output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second ** 2")),
+    ),
+)
+
 # Add and enable the context
 pnpq_ureg.add_context(thorlabs_context)
 pnpq_ureg.enable_contexts("thorlabs_context")

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -157,7 +157,7 @@ thorlabs_context.add_transformation(
 # Add K10CR1 velocity transformations.
 #
 # There are two ways to think about the K10CR1's velocity.
-# 
+#
 # The first, ``k10cr1_step / second``, represents the number of steps traversed per second. This value is probably the easiest for an end-user to understand.
 #
 # The second, ``k10cr1_velocity``, represents the velocity as the K10CR1's motor controller understands it. This value is used internally in the ``VELPARAMS`` messages.

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -180,8 +180,9 @@ thorlabs_context.add_transformation(
     "k10cr1_velocity",
     "k10cr1_step / second",
     get_unit_transformation(
-        input_to_output=lambda degrees_per_second: degrees_per_second * 136533,
-        input_unit=cast(Unit, pnpq_ureg("degree / second")),
+        input_to_output=lambda degrees_per_second: (degrees_per_second * 136533)
+        / 7329109,
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
     ),
 )
@@ -190,13 +191,10 @@ thorlabs_context.add_transformation(
     "k10cr1_step / second",
     "k10cr1_velocity",
     get_unit_transformation(
-        input_to_output=lambda step_per_second: (
-            step_per_second / 136533 * pnpq_ureg("degree / second")
-        )
-        .to("k10cr1_velocity")
-        .magnitude,
+        input_to_output=lambda step_per_second: (step_per_second / 136533) * 7329109,
         input_unit=cast(Unit, pnpq_ureg("k10cr1_step / second")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_velocity")),
+        output_rounded=True,
     ),
 )
 
@@ -227,12 +225,11 @@ thorlabs_context.add_transformation(
     "k10cr1_acceleration",
     get_unit_transformation(
         input_to_output=lambda steps_per_sec_squared: (
-            steps_per_sec_squared / 136533 * pnpq_ureg("degree / second ** 2")
-        )
-        .to("k10cr1_acceleration")
-        .magnitude,
+            (steps_per_sec_squared / 136533) * 1502
+        ),
         input_unit=cast(Unit, pnpq_ureg("k10cr1_step / second ** 2")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
+        output_rounded=True,
     ),
 )
 
@@ -240,9 +237,9 @@ thorlabs_context.add_transformation(
     "k10cr1_acceleration",
     "k10cr1_step / second ** 2",
     get_unit_transformation(
-        input_to_output=lambda degrees_per_sec_squared: degrees_per_sec_squared
+        input_to_output=lambda k10cr1_acceleration: (k10cr1_acceleration / 1502)
         * 136533,
-        input_unit=cast(Unit, pnpq_ureg("degrees / second ** 2")),
+        input_unit=cast(Unit, pnpq_ureg("k10cr1_acceleration")),
         output_unit=cast(Unit, pnpq_ureg("k10cr1_step / second ** 2")),
     ),
 )

--- a/src/pnpq/units.py
+++ b/src/pnpq/units.py
@@ -154,7 +154,15 @@ thorlabs_context.add_transformation(
     ),
 )
 
-# Add K10CR1 velocity transformations
+# Add K10CR1 velocity transformations.
+#
+# There are two ways to think about the K10CR1's velocity.
+# 
+# The first, ``k10cr1_step / second``, represents the number of steps traversed per second. This value is probably the easiest for an end-user to understand.
+#
+# The second, ``k10cr1_velocity``, represents the velocity as the K10CR1's motor controller understands it. This value is used internally in the ``VELPARAMS`` messages.
+#
+# Transformations to degrees or radians per second are of course also available.
 thorlabs_context.add_transformation(
     "degree / second",
     "k10cr1_velocity",

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -145,7 +145,7 @@ def test_to_mpc320_velocity_out_of_bounds(velocity: Quantity) -> None:
 
 
 # Test that [angle] / second quantities accurately convert into k10cr1_velocity quantities
-# According to the protocol (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
+# According to the protocol documentation (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
 @pytest.mark.parametrize(
     "angular_velocity, k10cr1_velocity",
     [

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -188,6 +188,10 @@ def test_from_k10cr1_velocity_conversion(
     assert angular_velocity.magnitude == pytest.approx(velocity.magnitude)
     assert angular_velocity.units == velocity.units
 
+    # Check if rounded correctly if output units are k10cr1_step per second
+    if angular_velocity.units == pnpq_ureg("k10cr1_step / second"):
+        assert isinstance(velocity.magnitude, int)
+
 
 # Test that k10cr1_acceleration quantities accurately convert into [angle] / second^2 quantities
 # According to the protocol (p.41), it states that we should convert 1 degree/sec^2 to 1502 steps/sec^2 for acceleration
@@ -232,3 +236,7 @@ def test_from_k10cr1_acceleration_conversion(
     acceleration = pint_k10cr1_acceleration.to(angular_acceleration.units)
     assert angular_acceleration.magnitude == pytest.approx(acceleration.magnitude)
     assert angular_acceleration.units == acceleration.units
+
+    # Check if rounded correctly if output units are k10cr1_step per second
+    if angular_acceleration.units == pnpq_ureg("k10cr1_step / second ** 2"):
+        assert isinstance(acceleration.magnitude, int)

--- a/tests/test_pint_units.py
+++ b/tests/test_pint_units.py
@@ -142,3 +142,93 @@ def test_to_mpc320_velocity_out_of_bounds(velocity: Quantity) -> None:
         match="Rounded mpc320_velocity [0-9]+ is out of range \\(10, 100\\)\\.",
     ):
         velocity.to(pnpq_ureg.mpc320_velocity)
+
+
+# Test that [angle] / second quantities accurately convert into k10cr1_velocity quantities
+# According to the protocol (p.41), it states that we should convert 1 degree/sec to 7329109 steps/sec for K10CR1.
+@pytest.mark.parametrize(
+    "angular_velocity, k10cr1_velocity",
+    [
+        (1 * pnpq_ureg("degree / second"), 7329109),
+        (2 * pnpq_ureg("degree / second"), 14658218),
+        (1.00000001 * pnpq_ureg("degree / second"), 7329109),
+        (1.99999999 * pnpq_ureg("degree / second"), 14658218),
+        (0.01745329251 * pnpq_ureg("radian / second"), 7329109),
+        (0.03490658503 * pnpq_ureg("radian / second"), 14658218),
+        (136533 * pnpq_ureg("k10cr1_step / second"), 7329109),
+        (273066 * pnpq_ureg("k10cr1_step / second"), 14658218),
+    ],
+)
+def test_to_k10cr1_velocity_conversion(
+    angular_velocity: Quantity, k10cr1_velocity: float
+) -> None:
+
+    pint_k10cr1_velocity = angular_velocity.to("k10cr1_velocity")
+    assert k10cr1_velocity == pint_k10cr1_velocity.magnitude
+    assert isinstance(pint_k10cr1_velocity.magnitude, int)
+
+
+@pytest.mark.parametrize(
+    "k10cr1_velocity, angular_velocity",
+    [
+        (7329109, 1 * pnpq_ureg("degree / second")),
+        (14658218, 2 * pnpq_ureg("degree / second")),
+        (7329109, 0.01745329251 * pnpq_ureg("radian / second")),
+        (14658218, 0.03490658503 * pnpq_ureg("radian / second")),
+        (7329109, 136533 * pnpq_ureg("k10cr1_step / second")),
+        (14658218, 273066 * pnpq_ureg("k10cr1_step / second")),
+    ],
+)
+def test_from_k10cr1_velocity_conversion(
+    k10cr1_velocity: float, angular_velocity: Quantity
+) -> None:
+
+    pint_k10cr1_velocity = k10cr1_velocity * pnpq_ureg.k10cr1_velocity
+    velocity = pint_k10cr1_velocity.to(angular_velocity.units)
+    assert angular_velocity.magnitude == pytest.approx(velocity.magnitude)
+    assert angular_velocity.units == velocity.units
+
+
+# Test that k10cr1_acceleration quantities accurately convert into [angle] / second^2 quantities
+# According to the protocol (p.41), it states that we should convert 1 degree/sec^2 to 1502 steps/sec^2 for acceleration
+@pytest.mark.parametrize(
+    "angular_acceleration, k10cr1_acceleration",
+    [
+        (1 * pnpq_ureg("degree / second ** 2"), 1502),
+        (2 * pnpq_ureg("degree / second ** 2"), 3004),
+        (1.0001 * pnpq_ureg("degree / second ** 2"), 1502),
+        (1.9999 * pnpq_ureg("degree / second ** 2"), 3004),
+        (0.01745329251 * pnpq_ureg("radian / second ** 2"), 1502),
+        (0.03490658503 * pnpq_ureg("radian / second ** 2"), 3004),
+        (136533 * pnpq_ureg("k10cr1_step / second ** 2"), 1502),
+        (273066 * pnpq_ureg("k10cr1_step / second ** 2"), 3004),
+    ],
+)
+def test_to_k10cr1_acceleration_conversion(
+    angular_acceleration: Quantity, k10cr1_acceleration: float
+) -> None:
+
+    pint_k10cr1_acceleration = angular_acceleration.to("k10cr1_acceleration")
+    assert k10cr1_acceleration == pint_k10cr1_acceleration.magnitude
+    assert isinstance(pint_k10cr1_acceleration.magnitude, int)
+
+
+@pytest.mark.parametrize(
+    "k10cr1_acceleration, angular_acceleration",
+    [
+        (1502, 1 * pnpq_ureg("degree / second ** 2")),
+        (3004, 2 * pnpq_ureg("degree / second ** 2")),
+        (1502, 0.01745329251 * pnpq_ureg("radian / second ** 2")),
+        (3004, 0.03490658503 * pnpq_ureg("radian / second ** 2")),
+        (1502, 136533 * pnpq_ureg("k10cr1_step / second ** 2")),
+        (3004, 273066 * pnpq_ureg("k10cr1_step / second ** 2")),
+    ],
+)
+def test_from_k10cr1_acceleration_conversion(
+    k10cr1_acceleration: float, angular_acceleration: Quantity
+) -> None:
+
+    pint_k10cr1_acceleration = k10cr1_acceleration * pnpq_ureg.k10cr1_acceleration
+    acceleration = pint_k10cr1_acceleration.to(angular_acceleration.units)
+    assert angular_acceleration.magnitude == pytest.approx(acceleration.magnitude)
+    assert angular_acceleration.units == acceleration.units


### PR DESCRIPTION
Working towards closing #104.

Hello. 11 PM coder here.

In order to add more functionality to the K10CR1 driver code, we need to implement messages such as `MGMSG_MOT_SET_VELPARAMS` and `MGMSG_MOT_GET_VELPARAMS`. However, these messages utilize new types of units: velocities and accelerations. This is what I worked on here.

## Additions 
* Added custom `k10cr1_velocity` and `k10cr1_acceleration` pint units.
* Added appropriate conversions to and from `degrees / second` and `degrees / second ** 2`.
* Added appropriate conversions to and from `k10cr1_step`as well (because `k10cr1_step` has its own dimension).
  *  One caveat is that we cannot convert between `mpc320_step` and `k10cr1_step` because of our custom dimensionality implementation, but that shouldn't be an issue.
* Added corresponding unit tests.

## References
[Thorlabs Protocol. See p.66 for SET_VELPARAMS and p.40~p.41 for definitions of K10CR1 velocity and acceleration](https://www.thorlabs.com/Software/Motion%20Control/APT_Communications_Protocol.pdf)