### PR TITLE
Implemented ABC for Thorlabs K10CR1 waveplate, stub device with tests

### DIFF
--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -19,6 +19,9 @@ from ..apt.protocol import (
 )
 
 class AbstractWaveplateThorlabsK10CR1(ABC):
+
+    _chan_ident = ChanIdent.CHANNEL_1
+
     @abstractmethod
     def move_absolute(self, position: Quantity) -> None:
         """Move the waveplate to a certain angle.
@@ -40,8 +43,6 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
 
     # Setup channels for the device
     available_channels: frozenset[ChanIdent] = frozenset([ChanIdent.CHANNEL_1])
-
-    _chan_ident = ChanIdent.CHANNEL_1
 
     def __post_init__(self) -> None:
         # Start polling thread

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -1,6 +1,7 @@
 import threading
 import time
 from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
 
 import structlog
 from pint import Quantity
@@ -17,16 +18,25 @@ from ..apt.protocol import (
     EnableState,
 )
 
+class AbstractWaveplateThorlabsK10CR1(ABC):
+    @abstractmethod
+    def move_absolute(self, position: Quantity) -> None:
+        """Move the waveplate to a certain angle.
+
+        :param position: The angle to move to.
+        """
+        pass
+
 
 @dataclass(frozen=True, kw_only=True)
-class WaveplateThorlabsK10CR1:
+class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
     connection: AptConnection
-
-    log = structlog.get_logger()
 
     # Polling threads
     tx_poller_thread: threading.Thread = field(init=False)
     tx_poller_thread_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    log = structlog.get_logger()
 
     # Setup channels for the device
     available_channels: frozenset[ChanIdent] = frozenset([ChanIdent.CHANNEL_1])

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -1,7 +1,7 @@
 import threading
 import time
-from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 import structlog
 from pint import Quantity
@@ -17,6 +17,7 @@ from ..apt.protocol import (
     ChanIdent,
     EnableState,
 )
+
 
 class AbstractWaveplateThorlabsK10CR1(ABC):
 

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -29,7 +29,6 @@ class AbstractWaveplateThorlabsK10CR1(ABC):
 
         :param position: The angle to move to.
         """
-        pass
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -4,12 +4,11 @@ from typing import cast
 import structlog
 from pint import Quantity
 
-from pnpq.apt.protocol import Address, UStatus, UStatusBits
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
 )
 
-from ..apt.protocol import AptMessage_MGMSG_MOT_GET_USTATUSUPDATE, ChanIdent
+from ..apt.protocol import ChanIdent
 from ..units import pnpq_ureg
 
 

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -5,19 +5,16 @@ import structlog
 from pint import Quantity
 
 from pnpq.apt.protocol import Address, UStatus, UStatusBits
-from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import AbstractWaveplateThorlabsK10CR1
-
-from ..apt.protocol import (
-    AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
-    ChanIdent,
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
+    AbstractWaveplateThorlabsK10CR1,
 )
+
+from ..apt.protocol import AptMessage_MGMSG_MOT_GET_USTATUSUPDATE, ChanIdent
 from ..units import pnpq_ureg
 
 
 @dataclass(frozen=True, kw_only=True)
-class WaveplateThorlabsK10CR1Stub(
-    AbstractWaveplateThorlabsK10CR1
-):
+class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
     log = structlog.get_logger()
 
     # Setup channels for the device

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, field
+from typing import cast
+
+import structlog
+from pint import Quantity
+
+from pnpq.apt.protocol import Address, UStatus, UStatusBits
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import AbstractWaveplateThorlabsK10CR1
+
+from ..apt.protocol import (
+    AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
+    ChanIdent,
+)
+from ..units import pnpq_ureg
+
+
+@dataclass(frozen=True, kw_only=True)
+class WaveplateThorlabsK10CR1Stub(
+    AbstractWaveplateThorlabsK10CR1
+):
+    log = structlog.get_logger()
+
+    # Setup channels for the device
+    available_channels: frozenset[ChanIdent] = frozenset(
+        [
+            ChanIdent.CHANNEL_1,
+        ]
+    )
+
+    # TODO: Add K10CR1 parameters
+    # current_params = None
+
+    current_state: dict[ChanIdent, Quantity] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.log.info("[Waveplate Stub] Initialized")
+
+        object.__setattr__(
+            self,
+            "current_state",
+            {
+                ChanIdent.CHANNEL_1: 0 * pnpq_ureg.k10cr1_step,
+            },
+        )
+
+    def move_absolute(self, position: Quantity) -> None:
+        # Convert distance to K1CR10 steps
+        # TODO: Check if input is too large or too small for the device
+        position_in_steps = position.to("k10cr1_step")
+        self.current_state[self._chan_ident] = cast(Quantity, position_in_steps)
+
+        self.log.info(f"[Waveplate Stub] Channel {self._chan_ident} move to {position}")

--- a/tests/test_polarization_controller_thorlabs_mpc320_stub.py
+++ b/tests/test_polarization_controller_thorlabs_mpc320_stub.py
@@ -11,7 +11,7 @@ from pnpq.units import pnpq_ureg
 
 
 @pytest.fixture(name="stub_mpc")
-def stub_waveplate_fixture() -> AbstractPolarizationControllerThorlabsMPC:
+def stub_mpc_fixture() -> AbstractPolarizationControllerThorlabsMPC:
     mpc = PolarizationControllerThorlabsMPC320Stub()
     return mpc
 

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -1,12 +1,6 @@
 import pytest
 
-from pnpq.apt.protocol import ChanIdent, JogDirection
-from pnpq.devices.polarization_controller_thorlabs_mpc import (
-    AbstractPolarizationControllerThorlabsMPC,
-)
-from pnpq.devices.polarization_controller_thorlabs_mpc_stub import (
-    PolarizationControllerThorlabsMPC320Stub,
-)
+from pnpq.apt.protocol import ChanIdent
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
 )

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -7,8 +7,12 @@ from pnpq.devices.polarization_controller_thorlabs_mpc import (
 from pnpq.devices.polarization_controller_thorlabs_mpc_stub import (
     PolarizationControllerThorlabsMPC320Stub,
 )
-from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import AbstractWaveplateThorlabsK10CR1
-from pnpq.devices.refactored_waveplate_thorlabs_k10cr1_stub import WaveplateThorlabsK10CR1Stub
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
+    AbstractWaveplateThorlabsK10CR1,
+)
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1_stub import (
+    WaveplateThorlabsK10CR1Stub,
+)
 from pnpq.units import pnpq_ureg
 
 
@@ -18,15 +22,13 @@ def stub_waveplate_fixture() -> AbstractWaveplateThorlabsK10CR1:
     return waveplate
 
 
-def test_move_absolute(
-    stub_waveplate: AbstractWaveplateThorlabsK10CR1
-) -> None:
+def test_move_absolute(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
     position = 45 * pnpq_ureg.degree
 
     stub_waveplate.move_absolute(position)
 
-    # TODO: Replace with get_params when implemented
-    waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]
+    # Currently throws a mypy error because current_state is not in the AbstractWaveplateThorlabsK10CR1.
+    # TODO: Replace with get_params when implemented.
+    waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]  # type: ignore
 
     assert waveplate_position.to("degree").magnitude == pytest.approx(45)
-

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pnpq.apt.protocol import ChanIdent, JogDirection
+from pnpq.devices.polarization_controller_thorlabs_mpc import (
+    AbstractPolarizationControllerThorlabsMPC,
+)
+from pnpq.devices.polarization_controller_thorlabs_mpc_stub import (
+    PolarizationControllerThorlabsMPC320Stub,
+)
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import AbstractWaveplateThorlabsK10CR1
+from pnpq.devices.refactored_waveplate_thorlabs_k10cr1_stub import WaveplateThorlabsK10CR1Stub
+from pnpq.units import pnpq_ureg
+
+
+@pytest.fixture(name="stub_waveplate")
+def stub_waveplate_fixture() -> AbstractWaveplateThorlabsK10CR1:
+    waveplate = WaveplateThorlabsK10CR1Stub()
+    return waveplate
+
+
+def test_move_absolute(
+    stub_waveplate: AbstractWaveplateThorlabsK10CR1
+) -> None:
+    position = 45 * pnpq_ureg.degree
+
+    stub_waveplate.move_absolute(position)
+
+    # TODO: Replace with get_params when implemented
+    waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]
+
+    assert waveplate_position.to("degree").magnitude == pytest.approx(45)
+


### PR DESCRIPTION
Closes #114 

## Implementations
* Added ABC implementation for K10CR1 waveplate
* Created a new refactored stub K10CR1 waveplate to incorporate the refactored K10CR1 waveplate class.
  * (Yes, I was told to refactor the old one, but after looking at the code, I thought it would be easier just to restart from scratch. It's really short anyway
  * This stub waveplate is super bare bones. It's going to fall apart any moment. But it should be good for now.
* Created respective tests for the new stub K10CR1 waveplate.
* Fixed small typo in MPC stub tests.