### PR TITLE
Add velparams functions to K10CR1 waveplate driver, stub and tests

### DIFF
--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -1,14 +1,14 @@
+from typing import Generator
 import pytest
 
 from pnpq.apt.connection import AptConnection
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
 
-
-@pytest.fixture(name="device", scope="module")
-def device_fixture() -> WaveplateThorlabsK10CR1:
-    connection = AptConnection(serial_number="55407714")
-    return WaveplateThorlabsK10CR1(connection=connection)
+@pytest.fixture(name="device", scope="function")
+def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
+    with AptConnection(serial_number="55409764") as connection:
+        yield WaveplateThorlabsK10CR1(connection=connection)
 
 
 def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -1,9 +1,11 @@
 from typing import Generator
+
 import pytest
 
 from pnpq.apt.connection import AptConnection
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
+
 
 @pytest.fixture(name="device", scope="function")
 def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -12,16 +12,7 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
     with AptConnection(serial_number="55409764") as connection:
         yield WaveplateThorlabsK10CR1(connection=connection)
 
-# def test_get_velparams(device: WaveplateThorlabsK10CR1) -> None:
-#     velparams = device.get_velparams()
-
 
 def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
-    # device.move_absolute(0 * pnpq_ureg.degree)
-    # Final :24575940
+    device.move_absolute(0 * pnpq_ureg.degree)
     device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
-    # device.move_absolute(180 * pnpq_ureg.degree)
-
-# def test_move_absolute2(device: WaveplateThorlabsK10CR1) -> None:
-#     # device.move_absolute(0 * pnpq_ureg.degree)
-#     device.move_absolute(180 * pnpq_ureg.degree)

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -12,6 +12,16 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
     with AptConnection(serial_number="55409764") as connection:
         yield WaveplateThorlabsK10CR1(connection=connection)
 
+# def test_get_velparams(device: WaveplateThorlabsK10CR1) -> None:
+#     velparams = device.get_velparams()
+
 
 def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
-    device.move_absolute(0 * pnpq_ureg.degree)
+    # device.move_absolute(0 * pnpq_ureg.degree)
+    # Final :24575940
+    device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
+    # device.move_absolute(180 * pnpq_ureg.degree)
+
+# def test_move_absolute2(device: WaveplateThorlabsK10CR1) -> None:
+#     # device.move_absolute(0 * pnpq_ureg.degree)
+#     device.move_absolute(180 * pnpq_ureg.degree)

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -753,6 +753,7 @@ class AptMessageWithDataPolParams(AptMessageWithData):
 
 # Concrete message implementation classes
 
+
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_SET_VELPARAMS(AptMessageWithDataVelParams):
     message_id = AptMessageId.MGMSG_MOT_SET_VELPARAMS

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -630,9 +630,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
     )
 
     chan_ident: ChanIdent
-    minimum_velocity: Quantity
-    acceleration: Quantity
-    maximum_velocity: Quantity
+    minimum_velocity: int
+    acceleration: int
+    maximum_velocity: int
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> Self:
@@ -664,9 +664,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
             destination=Address(destination & 0x7F),
             source=Address(source),
             chan_ident=ChanIdent(chan_ident),
-            minimum_velocity=minimum_velocity * pnpq_ureg.k10cr1_velocity,
-            acceleration=acceleration * pnpq_ureg.k10cr1_acceleration,
-            maximum_velocity=maximum_velocity * pnpq_ureg.k10cr1_velocity,
+            minimum_velocity=minimum_velocity,
+            acceleration=acceleration,
+            maximum_velocity=maximum_velocity,
         )
 
     def to_bytes(self) -> bytes:
@@ -676,9 +676,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
             self.destination_serialization,
             self.source,
             self.chan_ident,
-            self.minimum_velocity.magnitude,
-            self.acceleration.magnitude,
-            self.maximum_velocity.magnitude,
+            self.minimum_velocity,
+            self.acceleration,
+            self.maximum_velocity,
         )
 
 

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -630,9 +630,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
     )
 
     chan_ident: ChanIdent
-    minimum_velocity: int
-    acceleration: int
-    maximum_velocity: int
+    minimum_velocity: Quantity
+    acceleration: Quantity
+    maximum_velocity: Quantity
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> Self:
@@ -664,9 +664,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
             destination=Address(destination & 0x7F),
             source=Address(source),
             chan_ident=ChanIdent(chan_ident),
-            minimum_velocity=minimum_velocity,
-            acceleration=acceleration,
-            maximum_velocity=maximum_velocity,
+            minimum_velocity=minimum_velocity * pnpq_ureg.k10cr1_velocity,
+            acceleration=acceleration * pnpq_ureg.k10cr1_acceleration,
+            maximum_velocity=maximum_velocity * pnpq_ureg.k10cr1_velocity,
         )
 
     def to_bytes(self) -> bytes:
@@ -676,9 +676,9 @@ class AptMessageWithDataVelParams(AptMessageWithData):
             self.destination_serialization,
             self.source,
             self.chan_ident,
-            self.minimum_velocity,
-            self.acceleration,
-            self.maximum_velocity,
+            self.minimum_velocity.magnitude,
+            self.acceleration.magnitude,
+            self.maximum_velocity.magnitude,
         )
 
 

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -753,11 +753,6 @@ class AptMessageWithDataPolParams(AptMessageWithData):
 
 # Concrete message implementation classes
 
-# MGMSG_MOT_SET_VELPARAMS = 0x0413
-# MGMSG_MOT_REQ_VELPARAMS = 0x0414
-# MGMSG_MOT_GET_VELPARAMS = 0x0415
-
-
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_MOT_SET_VELPARAMS(AptMessageWithDataVelParams):
     message_id = AptMessageId.MGMSG_MOT_SET_VELPARAMS

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -48,6 +48,10 @@ class AptMessageId(int, Enum):
     MGMSG_POL_REQ_PARAMS = 0x0531
     MGMSG_POL_SET_PARAMS = 0x0530
 
+    MGMSG_MOT_SET_VELPARAMS = 0x0413
+    MGMSG_MOT_REQ_VELPARAMS = 0x0414
+    MGMSG_MOT_GET_VELPARAMS = 0x0415
+
     MGMSG_MOT_MOVE_JOG = 0x046A
     MGMSG_MOT_MOVE_STOP = 0x0465
     MGMSG_MOT_MOVE_STOPPED = 0x0466
@@ -615,6 +619,15 @@ class AptMessageWithDataMotorStatus(AptMessageWithData):
             self.status.to_bits(),
         )
 
+@dataclass(frozen=True, kw_only=True)
+class AptMessageWithDataVelParams(AptMessageWithData):
+    # Used in MGMSG_MOT_SET_VELPARAMS, MGMSG_MOT_GET_VELPARAMS
+
+    data_length: ClassVar[int] = 14
+
+    message_struct: ClassVar[Struct] = Struct(
+        f"{AptMessageWithData.header_struct_str}{ATS.WORD}2{ATS.LONG}2{ATS.WORD}2"
+    )
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessageWithDataPolParams(AptMessageWithData):
@@ -687,6 +700,24 @@ class AptMessageWithDataPolParams(AptMessageWithData):
 
 # Concrete message implementation classes
 
+    # MGMSG_MOT_SET_VELPARAMS = 0x0413
+    # MGMSG_MOT_REQ_VELPARAMS = 0x0414
+    # MGMSG_MOT_GET_VELPARAMS = 0x0415
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_REQ_VELPARAMS(AptMessageHeaderOnlyChanIdent):
+    message_id = AptMessageId.MGMSG_MOT_SET_VELPARAMS
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_SET_VELPARAMS(AptMessageWithData):
+    message_id = AptMessageId.MGMSG_MOT_REQ_VELPARAMS
+    data_length: ClassVar[int] = 14
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_GET_VELPARAMS(AptMessageWithData):
+    message_id = AptMessageId.MGMSG_MOT_GET_VELPARAMS
 
 @dataclass(frozen=True, kw_only=True)
 class AptMessage_MGMSG_HW_DISCONNECT(AptMessageHeaderOnlyNoParams):

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -331,7 +331,7 @@ class PolarizationControllerThorlabsMPC(AbstractPolarizationControllerThorlabsMP
                 source=Address.HOST_CONTROLLER,
                 velocity=round(
                     params["velocity"].magnitude
-                ),  # Note: Should probably convert these to correct units before getting magnitude.
+                ),  # TODO: Should probably convert these to correct units before getting magnitude.
                 home_position=round(params["home_position"].magnitude),
                 jog_step_1=round(params["jog_step_1"].magnitude),
                 jog_step_2=round(params["jog_step_2"].magnitude),

--- a/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
+++ b/src/pnpq/devices/polarization_controller_thorlabs_mpc.py
@@ -329,7 +329,9 @@ class PolarizationControllerThorlabsMPC(AbstractPolarizationControllerThorlabsMP
             AptMessage_MGMSG_POL_SET_PARAMS(
                 destination=Address.GENERIC_USB,
                 source=Address.HOST_CONTROLLER,
-                velocity=round(params["velocity"].magnitude),
+                velocity=round(
+                    params["velocity"].magnitude
+                ),  # Note: Should probably convert these to correct units before getting magnitude.
                 home_position=round(params["home_position"].magnitude),
                 jog_step_1=round(params["jog_step_1"].magnitude),
                 jog_step_2=round(params["jog_step_2"].magnitude),

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -2,7 +2,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import cast
+from typing import TypedDict, cast
 
 import structlog
 from pint import Quantity
@@ -20,6 +20,19 @@ from ..apt.protocol import (
     ChanIdent,
     EnableState,
 )
+
+
+class WaveplateVelocityParams(TypedDict):
+    """TypedDict for waveplate velocity parameters.
+    Used in `get_velparams` method.
+    """
+
+    #: Dimensionality must be ([angle] / [time]) or k10cr1_velocity
+    minimum_velocity: Quantity
+    #: Dimensionality must be ([angle] / [time] ** 2) or k10cr1_acceleration
+    acceleration: Quantity
+    #: Dimensionality must be ([angle] / [time]) or k10cr1_velocity
+    maximum_velocity: Quantity
 
 
 class AbstractWaveplateThorlabsK10CR1(ABC):

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -45,9 +45,8 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
             {
                 "minimum_velocity": 0 * pnpq_ureg.k10cr1_velocity,
                 "acceleration": 0 * pnpq_ureg.k10cr1_acceleration,
-                "maximum_velocity": 0
-                * pnpq_ureg.k10cr1_velocity,  # TODO: Search for appropriate initial values
-            },
+                "maximum_velocity": 10
+                * pnpq_ureg.k10cr1_velocity,  # Default value set to 10 k10cr1_velocity based on expected operational range
         )
 
     def move_absolute(self, position: Quantity) -> None:

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -8,7 +8,7 @@ from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
 )
 
-from ..apt.protocol import ChanIdent
+from ..apt.protocol import Address, AptMessage_MGMSG_MOT_GET_VELPARAMS, ChanIdent
 from ..units import pnpq_ureg
 
 
@@ -46,3 +46,14 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
         self.current_state[self._chan_ident] = cast(Quantity, position_in_steps)
 
         self.log.info(f"[Waveplate Stub] Channel {self._chan_ident} move to {position}")
+
+    def get_velparams(self) -> AptMessage_MGMSG_MOT_GET_VELPARAMS:
+        return AptMessage_MGMSG_MOT_GET_VELPARAMS(
+            destination=Address.HOST_CONTROLLER,
+            source=Address.GENERIC_USB,
+            chan_ident=self._chan_ident,
+            minimum_velocity=0,
+            acceleration=1,
+            maximum_velocity=2, # Not sure what to put here
+
+        )

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -47,6 +47,7 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
                 "acceleration": 0 * pnpq_ureg.k10cr1_acceleration,
                 "maximum_velocity": 10
                 * pnpq_ureg.k10cr1_velocity,  # Default value set to 10 k10cr1_velocity based on expected operational range
+            },
         )
 
     def move_absolute(self, position: Quantity) -> None:

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -24,7 +24,7 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
         ]
     )
 
-    current_params: WaveplateVelocityParams = field(init=False)
+    current_velocity_params: WaveplateVelocityParams = field(init=False)
 
     current_state: dict[ChanIdent, Quantity] = field(init=False)
 
@@ -41,7 +41,7 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
 
         object.__setattr__(
             self,
-            "current_params",
+            "current_velocity_params",
             {
                 "minimum_velocity": 0 * pnpq_ureg.k10cr1_velocity,
                 "acceleration": 0 * pnpq_ureg.k10cr1_acceleration,
@@ -59,7 +59,7 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
         self.log.info(f"[Waveplate Stub] Channel {self._chan_ident} move to {position}")
 
     def get_velparams(self) -> WaveplateVelocityParams:
-        return self.current_params
+        return self.current_velocity_params
 
     def set_velparams(
         self,
@@ -69,15 +69,17 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
     ) -> None:
 
         if minimum_velocity is not None:
-            self.current_params["minimum_velocity"] = cast(
+            self.current_velocity_params["minimum_velocity"] = cast(
                 Quantity, minimum_velocity.to("k10cr1_velocity")
             )
         if acceleration is not None:
-            self.current_params["acceleration"] = cast(
+            self.current_velocity_params["acceleration"] = cast(
                 Quantity, acceleration.to("k10cr1_acceleration")
             )
         if maximum_velocity is not None:
-            self.current_params["maximum_velocity"] = cast(
+            self.current_velocity_params["maximum_velocity"] = cast(
                 Quantity, maximum_velocity.to("k10cr1_velocity")
             )
-        self.log.info(f"[K10CR1 Stub] Updated parameters: {self.current_params}")
+        self.log.info(
+            f"[K10CR1 Stub] Updated parameters: {self.current_velocity_params}"
+        )

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -18,6 +18,7 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_GET_POSCOUNTER,
     AptMessage_MGMSG_MOT_GET_STATUSUPDATE,
     AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
+    AptMessage_MGMSG_MOT_GET_VELPARAMS,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES,
@@ -32,6 +33,7 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE,
     AptMessage_MGMSG_MOT_SET_EEPROMPARAMS,
     AptMessage_MGMSG_MOT_SET_POSCOUNTER,
+    AptMessage_MGMSG_MOT_SET_VELPARAMS,
     AptMessage_MGMSG_POL_GET_PARAMS,
     AptMessage_MGMSG_POL_REQ_PARAMS,
     AptMessage_MGMSG_POL_SET_PARAMS,
@@ -686,8 +688,6 @@ def test_AptMessage_MGMSG_RESTOREFACTORYSETTINGS_to_bytes() -> None:
 # We have not implemented any messages that are to be saved with SET_EEPROMPARAMS,
 # so MGMSG_HW_GET_INFO will temporarily be used as the target for saving in this
 # AptMessage_MGMSG_MOT_SET_EEPROMPARAMS unit test.
-
-
 def test_AptMessage_MGMSG_MOT_SET_EEPROMPARAMS_from_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_SET_EEPROMPARAMS.from_bytes(
         bytes.fromhex("B904 0400 D0 01 0100 0600")
@@ -708,6 +708,60 @@ def test_AptMessage_MGMSG_MOT_SET_EEPROMPARAMS_to_bytes() -> None:
         message_id_to_save=AptMessageId.MGMSG_HW_GET_INFO,
     )
     assert msg.to_bytes() == bytes.fromhex("B904 0400 D0 01 0100 0600")
+
+
+def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_VELPARAMS.from_bytes(
+        bytes.fromhex("1304 0E00 A2 01 0100 00000000 B0350000 CDCCCC00")
+    )
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0413
+    assert msg.source == 0x01
+    assert msg.chan_ident == 0x01
+    assert msg.minimum_velocity == 0x00000000
+    assert msg.acceleration == 0x000035B0
+    assert msg.maximum_velocity == 0x00CCCCCD
+
+
+def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_VELPARAMS(
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        chan_ident=ChanIdent.CHANNEL_1,
+        minimum_velocity=0x00000000,
+        acceleration=0x000035B0,
+        maximum_velocity=0x00CCCCCD,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "1304 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"
+    )
+
+
+def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_VELPARAMS.from_bytes(
+        bytes.fromhex("1504 0E00 A2 01 0100 00000000 B0350000 CDCCCC00")
+    )
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0415
+    assert msg.source == 0x01
+    assert msg.chan_ident == 0x01
+    assert msg.minimum_velocity == 0x00000000
+    assert msg.acceleration == 0x000035B0
+    assert msg.maximum_velocity == 0x00CCCCCD
+
+
+def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_VELPARAMS(
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        chan_ident=ChanIdent.CHANNEL_1,
+        minimum_velocity=0x00000000,
+        acceleration=0x000035B0,
+        maximum_velocity=0x00CCCCCD,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "1504 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -718,9 +718,9 @@ def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0413
     assert msg.source == 0x01
     assert msg.chan_ident == 0x01
-    assert msg.minimum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00000000
-    assert msg.acceleration.to(pnpq_ureg.k10cr1_acceleration).magnitude == 0x000035B0
-    assert msg.maximum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00CCCCCD
+    assert msg.minimum_velocity == 0x00000000
+    assert msg.acceleration == 0x000035B0
+    assert msg.maximum_velocity == 0x00CCCCCD
 
 
 def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_to_bytes() -> None:
@@ -728,9 +728,9 @@ def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_to_bytes() -> None:
         destination=Address.BAY_1,
         source=Address.HOST_CONTROLLER,
         chan_ident=ChanIdent.CHANNEL_1,
-        minimum_velocity=0x00000000 * pnpq_ureg.k10cr1_velocity,
-        acceleration=0x000035B0 * pnpq_ureg.k10cr1_acceleration,
-        maximum_velocity=0x00CCCCCD * pnpq_ureg.k10cr1_velocity,
+        minimum_velocity=0x00000000,
+        acceleration=0x000035B0,
+        maximum_velocity=0x00CCCCCD,
     )
     assert msg.to_bytes() == bytes.fromhex(
         "1304 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"
@@ -745,9 +745,9 @@ def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0415
     assert msg.source == 0x01
     assert msg.chan_ident == 0x01
-    assert msg.minimum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00000000
-    assert msg.acceleration.to(pnpq_ureg.k10cr1_acceleration).magnitude == 0x000035B0
-    assert msg.maximum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00CCCCCD
+    assert msg.minimum_velocity == 0x00000000
+    assert msg.acceleration == 0x000035B0
+    assert msg.maximum_velocity == 0x00CCCCCD
 
 
 def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
@@ -755,9 +755,9 @@ def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
         destination=Address.BAY_1,
         source=Address.HOST_CONTROLLER,
         chan_ident=ChanIdent.CHANNEL_1,
-        minimum_velocity=0x00000000 * pnpq_ureg.k10cr1_velocity,
-        acceleration=0x000035B0 * pnpq_ureg.k10cr1_acceleration,
-        maximum_velocity=0x00CCCCCD * pnpq_ureg.k10cr1_velocity,
+        minimum_velocity=0x00000000,
+        acceleration=0x000035B0,
+        maximum_velocity=0x00CCCCCD,
     )
     assert msg.to_bytes() == bytes.fromhex(
         "1504 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -718,9 +718,9 @@ def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0413
     assert msg.source == 0x01
     assert msg.chan_ident == 0x01
-    assert msg.minimum_velocity == 0x00000000
-    assert msg.acceleration == 0x000035B0
-    assert msg.maximum_velocity == 0x00CCCCCD
+    assert msg.minimum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00000000
+    assert msg.acceleration.to(pnpq_ureg.k10cr1_acceleration).magnitude == 0x000035B0
+    assert msg.maximum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00CCCCCD
 
 
 def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_to_bytes() -> None:
@@ -728,9 +728,9 @@ def test_AptMessage_MGMSG_MOT_SET_VELPARAMS_to_bytes() -> None:
         destination=Address.BAY_1,
         source=Address.HOST_CONTROLLER,
         chan_ident=ChanIdent.CHANNEL_1,
-        minimum_velocity=0x00000000,
-        acceleration=0x000035B0,
-        maximum_velocity=0x00CCCCCD,
+        minimum_velocity=0x00000000 * pnpq_ureg.k10cr1_velocity,
+        acceleration=0x000035B0 * pnpq_ureg.k10cr1_acceleration,
+        maximum_velocity=0x00CCCCCD * pnpq_ureg.k10cr1_velocity,
     )
     assert msg.to_bytes() == bytes.fromhex(
         "1304 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"
@@ -745,9 +745,9 @@ def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0415
     assert msg.source == 0x01
     assert msg.chan_ident == 0x01
-    assert msg.minimum_velocity == 0x00000000
-    assert msg.acceleration == 0x000035B0
-    assert msg.maximum_velocity == 0x00CCCCCD
+    assert msg.minimum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00000000
+    assert msg.acceleration.to(pnpq_ureg.k10cr1_acceleration).magnitude == 0x000035B0
+    assert msg.maximum_velocity.to(pnpq_ureg.k10cr1_velocity).magnitude == 0x00CCCCCD
 
 
 def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
@@ -755,9 +755,9 @@ def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
         destination=Address.BAY_1,
         source=Address.HOST_CONTROLLER,
         chan_ident=ChanIdent.CHANNEL_1,
-        minimum_velocity=0x00000000,
-        acceleration=0x000035B0,
-        maximum_velocity=0x00CCCCCD,
+        minimum_velocity=0x00000000 * pnpq_ureg.k10cr1_velocity,
+        acceleration=0x000035B0 * pnpq_ureg.k10cr1_acceleration,
+        maximum_velocity=0x00CCCCCD * pnpq_ureg.k10cr1_velocity,
     )
     assert msg.to_bytes() == bytes.fromhex(
         "1504 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -26,3 +26,17 @@ def test_move_absolute(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
     waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]  # type: ignore
 
     assert waveplate_position.to("degree").magnitude == pytest.approx(45)
+
+
+def test_velparams(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
+    stub_waveplate.set_velparams(
+        minimum_velocity=1 * pnpq_ureg.k10cr1_velocity,
+        acceleration=2 * pnpq_ureg.k10cr1_acceleration,
+        maximum_velocity=3 * pnpq_ureg.k10cr1_velocity,
+    )
+
+    velparams = stub_waveplate.get_velparams()
+
+    assert velparams["minimum_velocity"].to("k10cr1_velocity").magnitude == 1
+    assert velparams["acceleration"].to("k10cr1_acceleration").magnitude == 2
+    assert velparams["maximum_velocity"].to("k10cr1_velocity").magnitude == 3


### PR DESCRIPTION
Helps in closing #104

## Additions
* Added `get_velparams` and `set_velparams` to `WaveplateThorlabsK10CR1` driver.
* Added three new messages `MGMSG_MOT_SET_VELPARAMS`, `MGMSG_MOT_REQ_VELPARAMS` and `MGMSG_MOT_GET_VELPARAMS`. 
  * Also added the corresponding unit tests.
* Also updated the stub K10CR1 device as well.
* Added a `current_velocity_params` to save the current parameters on the stub device.
* Updated the protocol to have the message store data in a `Quantity` instead of `int` so users can easily change units.
