### PR TITLE
Add more APT messages!

### DIFF
--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -190,7 +190,7 @@ class JogDirection(int, Enum):
 class HomeDirection(int, Enum):
     """Used in MSMSG_MOT_SET_HOMEPARAMS, MSMSG_MOT_GET_HOMEPARAMS."""
 
-    FORWARD_0 = 0x00 # The example in the documentation shows zero as a possible value (unused), which we will take to be as forward.
+    FORWARD_0 = 0x00  # The example in the documentation shows zero as a possible value (unused), which we will take to be as forward.
     FORWARD = 0x01
     REVERSE = 0x02
 
@@ -200,7 +200,8 @@ class LimitSwitch(int, Enum):
     """The limit switch associated with the home position.
     Used in MSMSG_MOT_SET_HOMEPARAMS, MSMSG_MOT_GET_HOMEPARAMS.
     """
-    NULL = 0x00 # This enum is not used in the example documentation for MSMSG_MOT_SET_HOMEPARAMS.
+
+    NULL = 0x00  # This enum is not used in the example documentation for MSMSG_MOT_SET_HOMEPARAMS.
     HARDWARE_REVERSE = 0x01
     HARDWARE_FORWARD = 0x04
 

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -186,7 +186,7 @@ class LimitSwitch(int, Enum):
     Used in MSMSG_MOT_SET_HOMEPARAMS, MSMSG_MOT_GET_HOMEPARAMS.
     """
 
-    NULL = 0x00  # This enum is not used in the example documentation for MSMSG_MOT_SET_HOMEPARAMS.
+    NULL = 0x00  # This value represents "not used" in the example documentation for MSMSG_MOT_SET_HOMEPARAMS.
     HARDWARE_REVERSE = 0x01
     HARDWARE_FORWARD = 0x04
 

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -70,21 +70,6 @@ class AptMessageId(int, Enum):
 
 
 @enum.unique
-class NotImplementedAptMessageId(int, Enum):
-    """These message IDs are not implemented in the APT
-    specification. They are included here for completeness, but they
-    should not be used."""
-
-    MGMSG_MOT_SET_JOGPARAMS = 0x0416
-    MGMSG_MOT_REQ_JOGPARAMS = 0x0417
-    MGMSG_MOT_GET_JOGPARAMS = 0x0418
-
-    MGMSG_MOT_SET_HOMEPARAMS = 0x0440
-    MGMSG_MOT_REQ_HOMEPARAMS = 0x0441
-    MGMSG_MOT_GET_HOMEPARAMS = 0x0442
-
-
-@enum.unique
 class Address(int, Enum):
     BAY_0 = 0x21
     BAY_1 = 0x22

--- a/src/pnpq/apt/protocol.py
+++ b/src/pnpq/apt/protocol.py
@@ -60,6 +60,29 @@ class AptMessageId(int, Enum):
 
     MGMSG_MOT_SET_EEPROMPARAMS = 0x04B9
 
+    MGMSG_MOT_SET_JOGPARAMS = 0x0416
+    MGMSG_MOT_REQ_JOGPARAMS = 0x0417
+    MGMSG_MOT_GET_JOGPARAMS = 0x0418
+
+    MGMSG_MOT_SET_HOMEPARAMS = 0x0440
+    MGMSG_MOT_REQ_HOMEPARAMS = 0x0441
+    MGMSG_MOT_GET_HOMEPARAMS = 0x0442
+
+
+@enum.unique
+class NotImplementedAptMessageId(int, Enum):
+    """These message IDs are not implemented in the APT
+    specification. They are included here for completeness, but they
+    should not be used."""
+
+    MGMSG_MOT_SET_JOGPARAMS = 0x0416
+    MGMSG_MOT_REQ_JOGPARAMS = 0x0417
+    MGMSG_MOT_GET_JOGPARAMS = 0x0418
+
+    MGMSG_MOT_SET_HOMEPARAMS = 0x0440
+    MGMSG_MOT_REQ_HOMEPARAMS = 0x0441
+    MGMSG_MOT_GET_HOMEPARAMS = 0x0442
+
 
 @enum.unique
 class Address(int, Enum):
@@ -140,8 +163,16 @@ class EnableState(int, Enum):
 
 
 @enum.unique
+class JogMode(int, Enum):
+    """Used in MGMSG_MOT_SET_JOGPARAMS."""
+
+    CONTINUOUS = 0x01
+    SINGLE_STEP = 0x02
+
+
+@enum.unique
 class StopMode(int, Enum):
-    """Used in MSMSG_MOT_MOVE_STOP."""
+    """Used in MSMSG_MOT_MOVE_STOP, MGMSG_MOT_SET_JOGPARAMS"""
 
     IMMEDIATE = 0x01
     CONTROLLED = 0x02
@@ -153,6 +184,25 @@ class JogDirection(int, Enum):
 
     FORWARD = 0x01
     REVERSE = 0x02
+
+
+@enum.unique
+class HomeDirection(int, Enum):
+    """Used in MSMSG_MOT_SET_HOMEPARAMS, MSMSG_MOT_GET_HOMEPARAMS."""
+
+    FORWARD_0 = 0x00 # The example in the documentation shows zero as a possible value (unused), which we will take to be as forward.
+    FORWARD = 0x01
+    REVERSE = 0x02
+
+
+@enum.unique
+class LimitSwitch(int, Enum):
+    """The limit switch associated with the home position.
+    Used in MSMSG_MOT_SET_HOMEPARAMS, MSMSG_MOT_GET_HOMEPARAMS.
+    """
+    NULL = 0x00 # This enum is not used in the example documentation for MSMSG_MOT_SET_HOMEPARAMS.
+    HARDWARE_REVERSE = 0x01
+    HARDWARE_FORWARD = 0x04
 
 
 @enum.unique
@@ -679,6 +729,142 @@ class AptMessageWithDataVelParams(AptMessageWithData):
             self.minimum_velocity,
             self.acceleration,
             self.maximum_velocity,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessageWithJogParams(AptMessageWithData):
+    data_length: ClassVar[int] = 22
+    message_struct: ClassVar[Struct] = Struct(
+        f"{AptMessageWithData.header_struct_str}2{ATS.WORD}4{ATS.LONG}{ATS.WORD}"
+    )
+
+    chan_ident: ChanIdent
+    jog_mode: JogMode
+    jog_step_size: int
+    jog_minimum_velocity: int
+    jog_acceleration: int
+    jog_maximum_velocity: int
+    jog_stop_mode: StopMode
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        (
+            message_id,
+            data_length,
+            destination,
+            source,
+            chan_ident,
+            jog_mode,
+            jog_step_size,
+            jog_minimum_velocity,
+            jog_acceleration,
+            jog_maximum_velocity,
+            jog_stop_mode,
+        ) = cls.message_struct.unpack(raw)
+
+        if message_id != cls.message_id:
+            raise ValueError(
+                f"Expected message ID {cls.message_id.value}, but received {message_id} instead. Full raw data was {raw!r}"
+            )
+        if data_length != cls.data_length:
+            raise ValueError(
+                f"Expected data packet length {cls.data_length}, but received {data_length} instead. Full raw data was {raw!r}"
+            )
+        if destination & 0x80 != 0x80:
+            raise ValueError(
+                f"Expected the destination's highest bit to be 1, indicating that a data packet follows, but it was 0. Full raw data was {raw!r}"
+            )
+
+        return cls(
+            destination=Address(destination & 0x7F),
+            source=Address(source),
+            chan_ident=ChanIdent(chan_ident),
+            jog_mode=jog_mode,
+            jog_step_size=jog_step_size,
+            jog_minimum_velocity=jog_minimum_velocity,
+            jog_acceleration=jog_acceleration,
+            jog_maximum_velocity=jog_maximum_velocity,
+            jog_stop_mode=jog_stop_mode,
+        )
+
+    def to_bytes(self) -> bytes:
+        return self.message_struct.pack(
+            self.message_id,
+            self.data_length,
+            self.destination_serialization,
+            self.source,
+            self.chan_ident,
+            self.jog_mode,
+            self.jog_step_size,
+            self.jog_minimum_velocity,
+            self.jog_acceleration,
+            self.jog_maximum_velocity,
+            self.jog_stop_mode,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessageWithHomeParams(AptMessageWithData):
+    data_length: ClassVar[int] = 14
+    message_struct: ClassVar[Struct] = Struct(
+        f"{AptMessageWithData.header_struct_str}3{ATS.WORD}2{ATS.LONG}"
+    )
+
+    chan_ident: ChanIdent
+    home_direction: HomeDirection
+    limit_switch: LimitSwitch
+    home_velocity: int
+    offset_distance: int
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        (
+            message_id,
+            data_length,
+            destination,
+            source,
+            chan_ident,
+            home_directiion,
+            limit_switch,
+            home_velocity,
+            offset_distance,
+        ) = cls.message_struct.unpack(raw)
+
+        if message_id != cls.message_id:
+            raise ValueError(
+                f"Expected message ID {cls.message_id.value}, but received {message_id} instead. Full raw data was {raw!r}"
+            )
+        if data_length != cls.data_length:
+            raise ValueError(
+                f"Expected data packet length {cls.data_length}, but received {data_length} instead. Full raw data was {raw!r}"
+            )
+        if destination & 0x80 != 0x80:
+            raise ValueError(
+                f"Expected the destination's highest bit to be 1, indicating that a data packet follows, but it was 0. Full raw data was {raw!r}"
+            )
+
+        return cls(
+            destination=Address(destination & 0x7F),
+            source=Address(source),
+            chan_ident=ChanIdent(chan_ident),
+            home_direction=HomeDirection(home_directiion),
+            limit_switch=LimitSwitch(limit_switch),
+            home_velocity=home_velocity,
+            offset_distance=offset_distance,
+        )
+
+    def to_bytes(self) -> bytes:
+        return self.message_struct.pack(
+            self.message_id,
+            self.data_length,
+            self.destination_serialization,
+            self.source,
+            self.chan_ident,
+            self.home_direction,
+            self.limit_switch,
+            self.home_velocity,
+            self.offset_distance,
         )
 
 
@@ -1285,3 +1471,33 @@ class AptMessage_MGMSG_MOT_SET_EEPROMPARAMS(AptMessageWithData):
             self.chan_ident,
             self.message_id_to_save,
         )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_SET_JOGPARAMS(AptMessageWithJogParams):
+    message_id = AptMessageId.MGMSG_MOT_SET_JOGPARAMS
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_GET_JOGPARAMS(AptMessageWithJogParams):
+    message_id = AptMessageId.MGMSG_MOT_GET_JOGPARAMS
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_REQ_JOGPARAMS(AptMessageHeaderOnlyChanIdent):
+    message_id = AptMessageId.MGMSG_MOT_REQ_JOGPARAMS
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_SET_HOMEPARAMS(AptMessageWithHomeParams):
+    message_id = AptMessageId.MGMSG_MOT_SET_HOMEPARAMS
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_REQ_HOMEPARAMS(AptMessageHeaderOnlyChanIdent):
+    message_id = AptMessageId.MGMSG_MOT_REQ_HOMEPARAMS
+
+
+@dataclass(frozen=True, kw_only=True)
+class AptMessage_MGMSG_MOT_GET_HOMEPARAMS(AptMessageWithHomeParams):
+    message_id = AptMessageId.MGMSG_MOT_GET_HOMEPARAMS

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -781,6 +781,14 @@ def test_AptMessage_MGMSG_MOT_REQ_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0414
     assert msg.source == 0x01
 
+def test_AptMessage_MGMSG_MOT_REQ_VELPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_REQ_VELPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.GENERIC_USB,
+        source=Address.HOST_CONTROLLER,
+    )
+    assert msg.to_bytes() == b"\x14\x04\x01\x00\x50\x01"
+
 
 def test_AptMessage_MGMSG_MOT_SET_JOGPARAMS_from_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_SET_JOGPARAMS.from_bytes(

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -873,9 +873,7 @@ def test_AptMessage_MGMSG_MOT_REQ_JOGPARAMS_to_bytes() -> None:
 
 def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_from_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_SET_HOMEPARAMS.from_bytes(
-        bytes.fromhex(
-            "4004 0E00 A201 0100 0000 0000 33333300 00000000"
-        )
+        bytes.fromhex("4004 0E00 A201 0100 0000 0000 33333300 00000000")
     )
 
     assert msg.chan_ident == ChanIdent.CHANNEL_1
@@ -886,6 +884,7 @@ def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_from_bytes() -> None:
     assert msg.limit_switch == 0x00
     assert msg.home_velocity == 0x00333333
     assert msg.offset_distance == 0x00000000
+
 
 def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_to_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_SET_HOMEPARAMS(
@@ -902,12 +901,9 @@ def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_to_bytes() -> None:
     )
 
 
-
 def test_AptMessage_MGMSG_MOT_GET_HOMEPARAMS_from_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_GET_HOMEPARAMS.from_bytes(
-        bytes.fromhex(
-            "4204 0E00 A201 0100 0000 0000 33333300 00000000"
-        )
+        bytes.fromhex("4204 0E00 A201 0100 0000 0000 33333300 00000000")
     )
 
     assert msg.chan_ident == ChanIdent.CHANNEL_1
@@ -918,6 +914,7 @@ def test_AptMessage_MGMSG_MOT_GET_HOMEPARAMS_from_bytes() -> None:
     assert msg.limit_switch == 0x00
     assert msg.home_velocity == 0x00333333
     assert msg.offset_distance == 0x00000000
+
 
 def test_AptMessage_MGMSG_MOT_REQ_HOMEPARAMS_from_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_REQ_HOMEPARAMS.from_bytes(b"\x41\x04\x01\x00\x50\x01")
@@ -940,7 +937,6 @@ def test_AptMessage_MGMSG_MOT_GET_HOMEPARAMS_to_bytes() -> None:
     assert msg.to_bytes() == bytes.fromhex(
         "4204 0E00 A201 0100 0000 0000 33333300 00000000"
     )
-
 
 
 @pytest.mark.parametrize(

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -15,6 +15,8 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOD_REQ_CHANENABLESTATE,
     AptMessage_MGMSG_MOD_SET_CHANENABLESTATE,
     AptMessage_MGMSG_MOT_ACK_USTATUSUPDATE,
+    AptMessage_MGMSG_MOT_GET_HOMEPARAMS,
+    AptMessage_MGMSG_MOT_GET_JOGPARAMS,
     AptMessage_MGMSG_MOT_GET_POSCOUNTER,
     AptMessage_MGMSG_MOT_GET_STATUSUPDATE,
     AptMessage_MGMSG_MOT_GET_USTATUSUPDATE,
@@ -28,10 +30,15 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_MOVE_JOG,
     AptMessage_MGMSG_MOT_MOVE_STOP,
     AptMessage_MGMSG_MOT_MOVE_STOPPED,
+    AptMessage_MGMSG_MOT_REQ_HOMEPARAMS,
+    AptMessage_MGMSG_MOT_REQ_JOGPARAMS,
     AptMessage_MGMSG_MOT_REQ_POSCOUNTER,
     AptMessage_MGMSG_MOT_REQ_STATUSUPDATE,
     AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE,
+    AptMessage_MGMSG_MOT_REQ_VELPARAMS,
     AptMessage_MGMSG_MOT_SET_EEPROMPARAMS,
+    AptMessage_MGMSG_MOT_SET_HOMEPARAMS,
+    AptMessage_MGMSG_MOT_SET_JOGPARAMS,
     AptMessage_MGMSG_MOT_SET_POSCOUNTER,
     AptMessage_MGMSG_MOT_SET_VELPARAMS,
     AptMessage_MGMSG_POL_GET_PARAMS,
@@ -43,7 +50,10 @@ from pnpq.apt.protocol import (
     EnableState,
     FirmwareVersion,
     HardwareType,
+    HomeDirection,
     JogDirection,
+    JogMode,
+    LimitSwitch,
     Status,
     StopMode,
     UStatus,
@@ -762,6 +772,175 @@ def test_AptMessage_MGMSG_MOT_GET_VELPARAMS_to_bytes() -> None:
     assert msg.to_bytes() == bytes.fromhex(
         "1504 0E00 A2 01 0100 00000000 B0350000 CDCCCC00"
     )
+
+
+def test_AptMessage_MGMSG_MOT_REQ_VELPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_REQ_VELPARAMS.from_bytes(b"\x14\x04\x01\x00\x50\x01")
+    assert msg.chan_ident == 0x01
+    assert msg.destination == 0x50
+    assert msg.message_id == 0x0414
+    assert msg.source == 0x01
+
+
+def test_AptMessage_MGMSG_MOT_SET_JOGPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_JOGPARAMS.from_bytes(
+        bytes.fromhex(
+            "1604 1600 A2 01 0100 0100 E8030000 00000000 B0350000 CDCCCC00 0200"
+        )
+    )
+
+    assert msg.chan_ident == ChanIdent.CHANNEL_1
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0416
+    assert msg.source == 0x01
+    assert msg.jog_mode == JogMode.CONTINUOUS
+    assert msg.jog_step_size == 1000
+    assert msg.jog_minimum_velocity == 0x00000000
+    assert msg.jog_acceleration == 0x000035B0
+    assert msg.jog_maximum_velocity == 0x00CCCCCD
+    assert msg.jog_stop_mode == StopMode.CONTROLLED
+
+
+def test_AptMessage_MGMSG_MOT_SET_JOGPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_JOGPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        jog_mode=JogMode.CONTINUOUS,
+        jog_step_size=1000,
+        jog_minimum_velocity=0x00000000,
+        jog_acceleration=0x000035B0,
+        jog_maximum_velocity=0x00CCCCCD,
+        jog_stop_mode=StopMode.CONTROLLED,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "1604 1600 A2 01 0100 0100 E8030000 00000000 B0350000 CDCCCC00 0200"
+    )
+
+
+def test_AptMessage_MGMSG_MOT_GET_JOGPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_JOGPARAMS.from_bytes(
+        bytes.fromhex(
+            "1804 1600 A2 01 0100 0100 E8030000 00000000 B0350000 CDCCCC00 0200"
+        )
+    )
+
+    assert msg.chan_ident == ChanIdent.CHANNEL_1
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0418
+    assert msg.source == 0x01
+    assert msg.jog_mode == JogMode.CONTINUOUS
+    assert msg.jog_step_size == 1000
+    assert msg.jog_minimum_velocity == 0x00000000
+    assert msg.jog_acceleration == 0x000035B0
+    assert msg.jog_maximum_velocity == 0x00CCCCCD
+    assert msg.jog_stop_mode == StopMode.CONTROLLED
+
+
+def test_AptMessage_MGMSG_MOT_GET_JOGPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_JOGPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        jog_mode=JogMode.CONTINUOUS,
+        jog_step_size=1000,
+        jog_minimum_velocity=0x00000000,
+        jog_acceleration=0x000035B0,
+        jog_maximum_velocity=0x00CCCCCD,
+        jog_stop_mode=StopMode.CONTROLLED,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "1804 1600 A2 01 0100 0100 E8030000 00000000 B0350000 CDCCCC00 0200"
+    )
+
+
+def test_AptMessage_MGMSG_MOT_REQ_JOGPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_REQ_JOGPARAMS.from_bytes(b"\x17\x04\x01\x00\x50\x01")
+    assert msg.chan_ident == 0x01
+    assert msg.destination == 0x50
+    assert msg.message_id == 0x0417
+    assert msg.source == 0x01
+
+
+def test_AptMessage_MGMSG_MOT_REQ_JOGPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_REQ_JOGPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.GENERIC_USB,
+        source=Address.HOST_CONTROLLER,
+    )
+    assert msg.to_bytes() == b"\x17\x04\x01\x00\x50\x01"
+
+
+def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_HOMEPARAMS.from_bytes(
+        bytes.fromhex(
+            "4004 0E00 A201 0100 0000 0000 33333300 00000000"
+        )
+    )
+
+    assert msg.chan_ident == ChanIdent.CHANNEL_1
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0440
+    assert msg.source == 0x01
+    assert msg.home_direction == 0x00
+    assert msg.limit_switch == 0x00
+    assert msg.home_velocity == 0x00333333
+    assert msg.offset_distance == 0x00000000
+
+def test_AptMessage_MGMSG_MOT_SET_HOMEPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_SET_HOMEPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.NULL,
+        home_velocity=0x00333333,
+        offset_distance=0x00000000,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "4004 0E00 A201 0100 0000 0000 33333300 00000000"
+    )
+
+
+
+def test_AptMessage_MGMSG_MOT_GET_HOMEPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_HOMEPARAMS.from_bytes(
+        bytes.fromhex(
+            "4204 0E00 A201 0100 0000 0000 33333300 00000000"
+        )
+    )
+
+    assert msg.chan_ident == ChanIdent.CHANNEL_1
+    assert msg.destination == 0x22
+    assert msg.message_id == 0x0442
+    assert msg.source == 0x01
+    assert msg.home_direction == 0x00
+    assert msg.limit_switch == 0x00
+    assert msg.home_velocity == 0x00333333
+    assert msg.offset_distance == 0x00000000
+
+def test_AptMessage_MGMSG_MOT_REQ_HOMEPARAMS_from_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_REQ_HOMEPARAMS.from_bytes(b"\x41\x04\x01\x00\x50\x01")
+    assert msg.chan_ident == 0x01
+    assert msg.destination == 0x50
+    assert msg.message_id == 0x0441
+    assert msg.source == 0x01
+
+
+def test_AptMessage_MGMSG_MOT_GET_HOMEPARAMS_to_bytes() -> None:
+    msg = AptMessage_MGMSG_MOT_GET_HOMEPARAMS(
+        chan_ident=ChanIdent.CHANNEL_1,
+        destination=Address.BAY_1,
+        source=Address.HOST_CONTROLLER,
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.NULL,
+        home_velocity=0x00333333,
+        offset_distance=0x00000000,
+    )
+    assert msg.to_bytes() == bytes.fromhex(
+        "4204 0E00 A201 0100 0000 0000 33333300 00000000"
+    )
+
 
 
 @pytest.mark.parametrize(

--- a/tests/apt/test_protocol.py
+++ b/tests/apt/test_protocol.py
@@ -781,6 +781,7 @@ def test_AptMessage_MGMSG_MOT_REQ_VELPARAMS_from_bytes() -> None:
     assert msg.message_id == 0x0414
     assert msg.source == 0x01
 
+
 def test_AptMessage_MGMSG_MOT_REQ_VELPARAMS_to_bytes() -> None:
     msg = AptMessage_MGMSG_MOT_REQ_VELPARAMS(
         chan_ident=ChanIdent.CHANNEL_1,


### PR DESCRIPTION
One step closer to closing #104.

## Additions
* Added six new APT messages:
  * `MGMSG_MOT_SET_JOGPARAMS`
  * `MGMSG_MOT_REQ_JOGPARAMS`
  * `MGMSG_MOT_GET_JOGPARAMS`
  * `MGMSG_MOT_SET_HOMEPARAMS`
  * `MGMSG_MOT_REQ_HOMEPARAMS`
  * `MGMSG_MOT_GET_HOMEPARAMS`
* Added a few new enums that the messages use.
* Also added their corresponding unit tests
   * Also added a unit test that was not added for `AptMessage_MGMSG_MOT_REQ_VELPARAMS`. My bad. Forgot to add that.