### PR TITLE
Add more functions to refactored ODL

### DIFF
--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
@@ -20,6 +20,7 @@ from ..apt.protocol import (
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
     AptMessage_MGMSG_MOT_MOVE_HOME,
+    AptMessage_MGMSG_MOT_MOVE_HOMED,
     AptMessage_MGMSG_MOT_MOVE_STOPPED_20_BYTES,
     AptMessage_MGMSG_MOT_REQ_HOMEPARAMS,
     AptMessage_MGMSG_MOT_REQ_USTATUSUPDATE,
@@ -212,7 +213,7 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
                 isinstance(
                     message,
                     (
-                        AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
+                        AptMessage_MGMSG_MOT_MOVE_HOMED,
                         AptMessage_MGMSG_MOT_MOVE_STOPPED_20_BYTES,
                     ),
                 )

--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
@@ -383,6 +383,8 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
 
     def jog(self, jog_direction: JogDirection) -> None:
         # TODO: Validate this function when the device is in continuous jog mode
+        #
+        # TODO: Fuzzy-match the stop position in the same way move_absolute does
         result = self.connection.send_message_expect_reply(
             AptMessage_MGMSG_MOT_MOVE_JOG(
                 chan_ident=self._chan_ident,
@@ -518,13 +520,10 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
             params["limit_switch"] = limit_switch
 
         if home_velocity is not None:
-            params["home_velocity"] = cast(
-                Quantity, home_velocity.to("kbd101_velocity")
-            )
+            params["home_velocity"] = home_velocity
+
         if offset_distance is not None:
-            params["offset_distance"] = cast(
-                Quantity, offset_distance.to("kbd101_position")
-            )
+            params["offset_distance"] = offset_distance
 
         self.connection.send_message_no_reply(
             AptMessage_MGMSG_MOT_SET_HOMEPARAMS(

--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
@@ -58,7 +58,7 @@ class OpticalDelayLineVelocityParams(TypedDict):
 
 
 class OpticalDelayLineJogParams(TypedDict):
-    """TypedDict for waveplate jog parameters.
+    """TypedDict for optical delay line jog parameters.
     Used in the `get_jogparams` method.
     """
 
@@ -81,7 +81,7 @@ class OpticalDelayLineHomeParams(TypedDict):
     Used in the `get_homeparams` method.
     """
 
-    #: The direction sense for a move to Home
+    # The direction to move while homing. For ODLs, this value is always positive (forward).
     home_direction: HomeDirection
     #: The limit switch associated with the home position
     limit_switch: LimitSwitch
@@ -108,7 +108,7 @@ class AbstractOpticalDelayLineThorlabsKBD101(ABC):
 
     @abstractmethod
     def move_absolute(self, position: Quantity) -> None:
-        """Move the device to a certain angle.
+        """Move the device to the specified position.
 
         :param position: The angle to move to.
         """
@@ -570,7 +570,7 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
         if jog_mode is not None:
             params["jog_mode"] = jog_mode
         if jog_step_size is not None:
-            params["jog_step_size"] = jog_step_size
+            params["jog_step_size"] = jog_step_size.to(pnpq_ureg.kbd101_position)
         if jog_minimum_velocity is not None:
             params["jog_minimum_velocity"] = jog_minimum_velocity
         if jog_acceleration is not None:

--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101_stub.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101_stub.py
@@ -4,10 +4,24 @@ from typing import cast
 import structlog
 from pint import Quantity
 
-from ..apt.protocol import ChanIdent
+from pnpq.apt.protocol import AptMessage_MGMSG_MOT_GET_USTATUSUPDATE
+
+from ..apt.protocol import (
+    Address,
+    ChanIdent,
+    HomeDirection,
+    JogDirection,
+    JogMode,
+    LimitSwitch,
+    StopMode,
+    UStatus,
+    UStatusBits,
+)
 from ..units import pnpq_ureg
 from .refactored_odl_thorlabs_kbd101 import (
     AbstractOpticalDelayLineThorlabsKBD101,
+    OpticalDelayLineHomeParams,
+    OpticalDelayLineJogParams,
     OpticalDelayLineVelocityParams,
 )
 
@@ -26,6 +40,8 @@ class OpticalDelayLineThorlabsKBD101Stub(AbstractOpticalDelayLineThorlabsKBD101)
     )
 
     current_velocity_params: OpticalDelayLineVelocityParams = field(init=False)
+    current_home_params: OpticalDelayLineHomeParams = field(init=False)
+    current_jog_params: OpticalDelayLineJogParams = field(init=False)
 
     current_state: dict[ChanIdent, Quantity] = field(init=False)
 
@@ -50,11 +66,34 @@ class OpticalDelayLineThorlabsKBD101Stub(AbstractOpticalDelayLineThorlabsKBD101)
             },
         )
 
+        object.__setattr__(
+            self,
+            "current_home_params",
+            {
+                "home_direction": HomeDirection.FORWARD,
+                "limit_switch": LimitSwitch.HARDWARE_FORWARD,
+                "home_velocity": 134218 * pnpq_ureg.kbd101_velocity,
+                "offset_distance": 0 * pnpq_ureg.kbd101_position,
+            },
+        )
+
+        object.__setattr__(
+            self,
+            "current_jog_params",
+            {
+                "jog_mode": JogMode.SINGLE_STEP,
+                "jog_step_size": 20000 * pnpq_ureg.kbd101_position,
+                "jog_minimum_velocity": 134218 * pnpq_ureg.kbd101_velocity,
+                "jog_acceleration": 7 * pnpq_ureg.kbd101_acceleration,
+                "jog_maximum_velocity": 134218 * pnpq_ureg.kbd101_velocity,
+                "jog_stop_mode": StopMode.CONTROLLED,
+            },
+        )
+
     def identify(self) -> None:
         self.log.info("[KBD101 Stub] Identify")
 
     def home(self) -> None:
-        # TODO: Update when set home params are implemented
         home_position = 0 * pnpq_ureg.kbd101_position
         self.log.info("[KBD101 Stub] Channel %s home", self._chan_ident)
 
@@ -68,6 +107,40 @@ class OpticalDelayLineThorlabsKBD101Stub(AbstractOpticalDelayLineThorlabsKBD101)
         self.log.info(
             "[KBD101 Stub] Channel %s move to %s", self._chan_ident, kbd101_position
         )
+
+    def jog(self, jog_direction: JogDirection) -> None:
+        jog_value = self.current_jog_params["jog_step_size"]
+        jog_value_magnitude = jog_value.to("kbd101_position").magnitude
+        current_value = (
+            self.current_state[self._chan_ident].to("kbd101_position").magnitude
+        )
+
+        if jog_direction == JogDirection.FORWARD:
+            new_value_magnitude = current_value + jog_value_magnitude
+        else:  # Reverse
+            new_value_magnitude = current_value - jog_value_magnitude
+
+        new_value = new_value_magnitude * pnpq_ureg.kbd101_position
+        self.current_state[self._chan_ident] = cast(Quantity, new_value)
+
+        self.log.info(
+            "[KBD101 Stub] Channel %s jog %s to %s",
+            self._chan_ident,
+            jog_direction,
+            new_value,
+        )
+
+    def get_status(self) -> AptMessage_MGMSG_MOT_GET_USTATUSUPDATE:
+        msg = AptMessage_MGMSG_MOT_GET_USTATUSUPDATE(
+            chan_ident=self._chan_ident,
+            position=self.current_state[self._chan_ident].magnitude,
+            velocity=self.current_velocity_params["maximum_velocity"].magnitude,
+            motor_current=3 * pnpq_ureg.milliamp,
+            status=UStatus.from_bits(UStatusBits.ACTIVE),
+            destination=Address.HOST_CONTROLLER,
+            source=Address.GENERIC_USB,
+        )
+        return msg
 
     def get_velparams(self) -> OpticalDelayLineVelocityParams:
         return self.current_velocity_params
@@ -94,3 +167,62 @@ class OpticalDelayLineThorlabsKBD101Stub(AbstractOpticalDelayLineThorlabsKBD101)
         self.log.info(
             "[KBD101 Stub] Updated parameters: %s", self.current_velocity_params
         )
+
+    def get_homeparams(self) -> OpticalDelayLineHomeParams:
+        return self.current_home_params
+
+    def set_homeparams(
+        self,
+        home_direction: HomeDirection | None = None,
+        limit_switch: LimitSwitch | None = None,
+        home_velocity: Quantity | None = None,
+        offset_distance: Quantity | None = None,
+    ) -> None:
+        if home_direction is not None:
+            self.current_home_params["home_direction"] = home_direction
+        if limit_switch is not None:
+            self.current_home_params["limit_switch"] = limit_switch
+        if home_velocity is not None:
+            self.current_home_params["home_velocity"] = cast(
+                Quantity, home_velocity.to("kbd101_velocity")
+            )
+        if offset_distance is not None:
+            self.current_home_params["offset_distance"] = cast(
+                Quantity, offset_distance.to("kbd101_position")
+            )
+        self.log.info("[KBD101 Stub] Updated parameters: %s", self.current_home_params)
+
+    def get_jogparams(self) -> OpticalDelayLineJogParams:
+        return self.current_jog_params
+
+    def set_jogparams(
+        self,
+        jog_mode: JogMode | None = None,
+        jog_step_size: Quantity | None = None,
+        jog_minimum_velocity: Quantity | None = None,
+        jog_acceleration: Quantity | None = None,
+        jog_maximum_velocity: Quantity | None = None,
+        jog_stop_mode: StopMode | None = None,
+    ) -> None:
+        if jog_mode is not None:
+            self.current_jog_params["jog_mode"] = jog_mode
+        if jog_step_size is not None:
+            self.current_jog_params["jog_step_size"] = cast(
+                Quantity, jog_step_size.to("kbd101_position")
+            )
+        if jog_minimum_velocity is not None:
+            self.current_jog_params["jog_minimum_velocity"] = cast(
+                Quantity, jog_minimum_velocity.to("kbd101_velocity")
+            )
+        if jog_acceleration is not None:
+            self.current_jog_params["jog_acceleration"] = cast(
+                Quantity, jog_acceleration.to("kbd101_acceleration")
+            )
+        if jog_maximum_velocity is not None:
+            self.current_jog_params["jog_maximum_velocity"] = cast(
+                Quantity, jog_maximum_velocity.to("kbd101_velocity")
+            )
+        if jog_stop_mode is not None:
+            self.current_jog_params["jog_stop_mode"] = jog_stop_mode
+
+        self.log.info("[KBD101 Stub] Updated parameters: %s", self.current_jog_params)

--- a/tests/test_refactored_thorlabs_kbd101_stub.py
+++ b/tests/test_refactored_thorlabs_kbd101_stub.py
@@ -1,6 +1,15 @@
-import pytest
+from typing import cast
 
-from pnpq.apt.protocol import ChanIdent
+import pytest
+from pint import Quantity
+
+from pnpq.apt.protocol import (
+    HomeDirection,
+    JogDirection,
+    JogMode,
+    LimitSwitch,
+    StopMode,
+)
 from pnpq.devices.refactored_odl_thorlabs_kbd101 import (
     AbstractOpticalDelayLineThorlabsKBD101,
 )
@@ -16,16 +25,30 @@ def stub_odl_fixture() -> AbstractOpticalDelayLineThorlabsKBD101:
     return odl
 
 
+def test_identify(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
+    stub_odl.identify()
+
+
+def test_home(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
+    stub_odl.home()
+
+    current_status = stub_odl.get_status()
+    current_position = cast(
+        Quantity, current_status.position * pnpq_ureg.kbd101_position
+    )
+    assert current_position.magnitude == 0
+
+
 def test_move_absolute(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
     position = 20 * pnpq_ureg.mm
 
     stub_odl.move_absolute(position)
 
-    # Currently throws a mypy error because current_state is not in the AbstractWaveplateThorlabsK10CR1.
-    # TODO: Replace with get_params when implemented.
-    odl_position = stub_odl.current_state[ChanIdent.CHANNEL_1]  # type: ignore
-
-    assert odl_position.magnitude == pytest.approx(40000)
+    current_status = stub_odl.get_status()
+    current_position = cast(
+        Quantity, current_status.position * pnpq_ureg.kbd101_position
+    )
+    assert current_position.magnitude == pytest.approx(40000)
 
 
 def test_velparams(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
@@ -40,3 +63,68 @@ def test_velparams(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
     assert velparams["minimum_velocity"].to("kbd101_velocity").magnitude == 0
     assert velparams["acceleration"].to("kbd101_acceleration").magnitude == 1374
     assert velparams["maximum_velocity"].to("kbd101_velocity").magnitude == 1342177
+
+
+def test_jogparams(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
+    stub_odl.set_jogparams(
+        jog_mode=JogMode.SINGLE_STEP,
+        jog_step_size=1 * pnpq_ureg.kbd101_position,
+        jog_minimum_velocity=2 * pnpq_ureg.kbd101_velocity,
+        jog_acceleration=3 * pnpq_ureg.kbd101_acceleration,
+        jog_maximum_velocity=4 * pnpq_ureg.kbd101_velocity,
+        jog_stop_mode=StopMode.IMMEDIATE,
+    )
+
+    jogparams = stub_odl.get_jogparams()
+    assert jogparams["jog_mode"] == JogMode.SINGLE_STEP
+    assert jogparams["jog_step_size"].to("kbd101_position").magnitude == 1
+    assert jogparams["jog_minimum_velocity"].to("kbd101_velocity").magnitude == 2
+    assert jogparams["jog_acceleration"].to("kbd101_acceleration").magnitude == 3
+    assert jogparams["jog_maximum_velocity"].to("kbd101_velocity").magnitude == 4
+    assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
+
+
+def test_jog(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
+    # Default jog for stub ODL is 10mm
+    stub_odl.jog(JogDirection.FORWARD)
+
+    current_status = stub_odl.get_status()
+    current_position = cast(
+        Quantity, current_status.position * pnpq_ureg.kbd101_position
+    )
+    # Default jog for stub ODL is 10mm
+    assert current_position.to("mm").magnitude == pytest.approx(10)
+
+    # Try setting the jog step size to 20mm
+    stub_odl.set_jogparams(
+        jog_step_size=20 * pnpq_ureg.mm,
+    )
+    stub_odl.jog(JogDirection.FORWARD)
+    current_status = stub_odl.get_status()
+    current_position = cast(
+        Quantity, current_status.position * pnpq_ureg.kbd101_position
+    )
+    assert current_position.to("mm").magnitude == pytest.approx(30)
+
+    # Test jog backward
+    stub_odl.jog(JogDirection.REVERSE)
+    current_status = stub_odl.get_status()
+    current_position = cast(
+        Quantity, current_status.position * pnpq_ureg.kbd101_position
+    )
+    assert current_position.to("mm").magnitude == pytest.approx(10)
+
+
+def test_homeparams(stub_odl: AbstractOpticalDelayLineThorlabsKBD101) -> None:
+    stub_odl.set_homeparams(
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.HARDWARE_FORWARD,
+        home_velocity=1 * pnpq_ureg.kbd101_velocity,
+        offset_distance=2 * pnpq_ureg.kbd101_position,
+    )
+
+    homeparams = stub_odl.get_homeparams()
+    assert homeparams["home_direction"] == HomeDirection.FORWARD_0
+    assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
+    assert homeparams["home_velocity"].to("kbd101_velocity").magnitude == 1
+    assert homeparams["offset_distance"].to("kbd101_position").magnitude == 2


### PR DESCRIPTION
Close #133 
Close #43 

This PR implemented a bit more than what's described in the original issue. 

- Added the following functions:
  - `jog`
  - `get_homeparams`
  - `set_homeparams`
  - `get_jogparams`
  - `set_jogparams`
  - `get_status`
- Updated stub device and unit tests (unit test now covers 100% of the stub device's code)
- Fixed some mistakes in documentation from the last PR (#126)

Now, the new ThorLabs ODL driver should be in feature parity with the old one (and even surpassed it in some areas). After this PR and #104 is finished, we can consider removing the old drivers (#121).

Another small thing to consider: the parameters class (`OpticalDelayLineVelocityParams`, etc.) are identical to the waveplate counterpart due to them using the same messages. Maybe we should consider merging them? The only difference is that the units used by the values are device-specific, but these are handles in the actual device implementation code, not in the parameter definition. 