### PR TITLE
Clean up some class variables

### DIFF
--- a/src/pnpq/apt/connection.py
+++ b/src/pnpq/apt/connection.py
@@ -27,15 +27,22 @@ from .protocol import (
 
 @dataclass(frozen=True, kw_only=True)
 class AptConnection:
-    # Serial connection parameters
-    baudrate: int = 115200
-    bytesize: int = serial.EIGHTBITS
-    exclusive: bool = True
-    parity: str = serial.PARITY_NONE
-    rtscts: bool = True
-    stopbits: int = serial.STOPBITS_ONE
-    timeout: None | int = (
-        None  # None means wait forever, until the requested number of bytes are received
+    # Required
+    serial_number: str
+
+    # All other properties are optional.
+
+    # Serial connection parameters. These defaults are used by all
+    # known Thorlabs devices that implement the APT protocol and do
+    # not need to be changed.
+    baudrate: int = field(default=115200)
+    bytesize: int = field(default=serial.EIGHTBITS)
+    exclusive: bool = field(default=True)
+    parity: str = field(default=serial.PARITY_NONE)
+    rtscts: bool = field(default=True)
+    stopbits: int = field(default=serial.STOPBITS_ONE)
+    timeout: None | int = field(
+        default=None  # None means wait forever, until the requested number of bytes are received
     )
 
     connection: Serial = field(init=False)
@@ -75,9 +82,6 @@ class AptConnection:
     log = structlog.get_logger()
 
     stop_event: threading.Event = field(default_factory=threading.Event)
-
-    # Required inputs are defined below.
-    serial_number: str
 
     def __enter__(self) -> "AptConnection":
         self.open()

--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
@@ -97,9 +97,6 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
 
     log = structlog.get_logger()
 
-    # Setup channels for the device
-    available_channels: frozenset[ChanIdent] = frozenset([ChanIdent.CHANNEL_1])
-
     def __post_init__(self) -> None:
         # Start polling thread
         object.__setattr__(

--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101_stub.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101_stub.py
@@ -18,13 +18,6 @@ class OpticalDelayLineThorlabsKBD101Stub(AbstractOpticalDelayLineThorlabsKBD101)
 
     log = structlog.get_logger()
 
-    # Setup channels for the device
-    available_channels: frozenset[ChanIdent] = frozenset(
-        [
-            ChanIdent.CHANNEL_1,
-        ]
-    )
-
     current_velocity_params: OpticalDelayLineVelocityParams = field(init=False)
 
     current_state: dict[ChanIdent, Quantity] = field(init=False)

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -79,9 +79,6 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
 
     log = structlog.get_logger()
 
-    # Setup channels for the device
-    available_channels: frozenset[ChanIdent] = frozenset([ChanIdent.CHANNEL_1])
-
     def __post_init__(self) -> None:
         # Start polling thread
         object.__setattr__(

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -19,13 +19,6 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
 
     log = structlog.get_logger()
 
-    # Setup channels for the device
-    available_channels: frozenset[ChanIdent] = frozenset(
-        [
-            ChanIdent.CHANNEL_1,
-        ]
-    )
-
     current_velocity_params: WaveplateVelocityParams = field(init=False)
 
     current_state: dict[ChanIdent, Quantity] = field(init=False)
@@ -37,7 +30,7 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
             self,
             "current_state",
             {
-                ChanIdent.CHANNEL_1: 0 * pnpq_ureg.k10cr1_step,
+                self._chan_ident: 0 * pnpq_ureg.k10cr1_step,
             },
         )
 


### PR DESCRIPTION
While doing another PR it occurred to me that it would be better if we avoided using class variables as much as possible, to prevent confusion.

I haven't touched the ones related to channel configuration, because I think that might interfere with some of the work you're doing. I did remove some unused variables. I think it might be a good idea to make the channel variables into instance variables, though.

I haven't touched anything in the protocol classes, since those are not plausibly reconfigurable and I doubt anyone will ever try to change those values.