### PR TITLE
Implement many functions for K10CR1 waveplate

### DIFF
--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -31,7 +31,7 @@ def test_connection() -> None:
 
 
 def test_homed_on_startup() -> None:
-    # Plug and replug the device before running this test.
+    # Unplug and replug the device before running this test.
     with AptConnection(serial_number="55409764") as connection:
         device = WaveplateThorlabsK10CR1(connection=connection)
         assert device.is_homed()

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -39,7 +39,7 @@ def test_homed_on_startup() -> None:
         assert device.is_homed()
 
 
-@pytest.fixture(name="device", scope="function")
+@pytest.fixture(name="device", scope="module")
 def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
     with AptConnection(serial_number="55409764") as connection:
         yield WaveplateThorlabsK10CR1(connection=connection)
@@ -102,7 +102,7 @@ def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
 
     assert homeparams["home_direction"] == HomeDirection.REVERSE
     assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_REVERSE
-    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 73286848
+    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 73291 * 500
     assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
 
     log.info("Home parameters test passed", homeparams=homeparams)

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -17,6 +17,7 @@ from pnpq.units import pnpq_ureg
 
 log = structlog.get_logger()
 
+
 def test_connection() -> None:
     with AptConnection(serial_number="55409764") as connection:
         assert not connection.is_closed()
@@ -103,7 +104,6 @@ def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
     assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_REVERSE
     assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 73286848
     assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
-
 
     log.info("Home parameters test passed", homeparams=homeparams)
 

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -1,13 +1,19 @@
 from typing import Generator
 
 import pytest
+import structlog
 
 from pnpq.apt.connection import AptConnection
-from pnpq.apt.protocol import HomeDirection, JogDirection, JogMode, LimitSwitch, StopMode
+from pnpq.apt.protocol import (
+    HomeDirection,
+    JogDirection,
+    JogMode,
+    LimitSwitch,
+    StopMode,
+)
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
 
-import structlog
 
 @pytest.fixture(name="device", scope="function")
 def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
@@ -15,73 +21,70 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
         yield WaveplateThorlabsK10CR1(connection=connection)
 
 
-# def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
-#     device.move_absolute(0 * pnpq_ureg.degree)
-#     device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
-
-# def test_jogparams(device: WaveplateThorlabsK10CR1) -> None:
-#     log = structlog.get_logger()
-#     device.set_jogparams(
-#         jog_mode=JogMode.SINGLE_STEP,
-#         jog_step_size=1 * pnpq_ureg.k10cr1_step,
-#         jog_minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
-#         jog_acceleration=3 * pnpq_ureg.k10cr1_acceleration,
-#         jog_maximum_velocity=4 * pnpq_ureg.k10cr1_velocity,
-#         jog_stop_mode=StopMode.IMMEDIATE,
-#     )
-
-#     jogparams = device.get_jogparams()
-
-#     assert jogparams["jog_mode"] == JogMode.SINGLE_STEP
-#     assert jogparams["jog_step_size"].to("k10cr1_step").magnitude == 1
-#     assert jogparams["jog_minimum_velocity"].to("k10cr1_velocity").magnitude == 0
-#     assert jogparams["jog_acceleration"].to("k10cr1_acceleration").magnitude == 3
-#     assert jogparams["jog_maximum_velocity"].to("k10cr1_velocity").magnitude == 4
-#     assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
-
-# def test_jog(device: WaveplateThorlabsK10CR1) -> None:
-#     device.set_jogparams(
-#         jog_mode=JogMode.SINGLE_STEP,
-#         jog_step_size=1 * pnpq_ureg.k10cr1_step,
-#         jog_minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
-#         jog_acceleration=30 * pnpq_ureg.degree / pnpq_ureg.second**2,
-#         jog_maximum_velocity= 10 * pnpq_ureg.degree / pnpq_ureg.second,
-#         jog_stop_mode=StopMode.IMMEDIATE,
-#     )
-
-#     log = structlog.get_logger()
-#     log.info("Starting jog test!!!")
-
-#     device.jog(
-#         jog_direction=JogDirection.FORWARD,
-#     )
-
-# def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
-    # log = structlog.get_logger()
-    # device.set_homeparams(
-    #     home_direction=HomeDirection.FORWARD_0,
-    #     limit_switch=LimitSwitch.HARDWARE_FORWARD,
-    #     home_velocity=1000000 * pnpq_ureg.k10cr1_velocity,
-    #     offset_distance=2 * pnpq_ureg.k10cr1_step,
-    # )
-
-    # homeparams = device.get_homeparams()
-
-    # assert homeparams["home_direction"] == HomeDirection.FORWARD_0
-    # assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
-    # assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1000000
-    # assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
-
-    # logger = structlog.get_logger()
-    # logger.info("Home parameters test passed", homeparams=homeparams)
+def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
+    device.move_absolute(0 * pnpq_ureg.degree)
+    device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
 
 
-# def test_home(device: WaveplateThorlabsK10CR1) -> None:
-#     logger = structlog.get_logger()
-#     logger.info("Starting home test")
-#     device.home()
+def test_jogparams(device: WaveplateThorlabsK10CR1) -> None:
+    device.set_jogparams(
+        jog_mode=JogMode.SINGLE_STEP,
+        jog_step_size=10 * pnpq_ureg.degree,
+        jog_minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
+        jog_acceleration=30 * pnpq_ureg.degree / pnpq_ureg.second**2,
+        jog_maximum_velocity=10 * pnpq_ureg.degree / pnpq_ureg.second,
+        jog_stop_mode=StopMode.IMMEDIATE,
+    )
+
+    jogparams = device.get_jogparams()
+    assert jogparams["jog_mode"] == JogMode.SINGLE_STEP
+    assert jogparams["jog_step_size"].to("k10cr1_step").magnitude == int(
+        (10 * pnpq_ureg.degree).to("k10cr1_step").magnitude
+    )
+    assert jogparams["jog_minimum_velocity"].to("k10cr1_velocity").magnitude == 0
+    assert jogparams["jog_acceleration"].to("k10cr1_acceleration").magnitude == int(
+        (30 * pnpq_ureg.degree / pnpq_ureg.second**2)
+        .to("k10cr1_acceleration")
+        .magnitude
+    )
+    assert jogparams["jog_maximum_velocity"].to("k10cr1_velocity").magnitude == int(
+        (10 * pnpq_ureg.degree / pnpq_ureg.second).to("k10cr1_velocity").magnitude
+    )
+    assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
+
+
+def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
+    device.set_homeparams(
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.HARDWARE_FORWARD,
+        home_velocity=1000000 * pnpq_ureg.k10cr1_velocity,
+        offset_distance=2 * pnpq_ureg.k10cr1_step,
+    )
+
+    homeparams = device.get_homeparams()
+
+    assert homeparams["home_direction"] == HomeDirection.FORWARD_0
+    assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
+    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1000000
+    assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
+
+    logger = structlog.get_logger()
+    logger.info("Home parameters test passed", homeparams=homeparams)
+
+
+def test_home(device: WaveplateThorlabsK10CR1) -> None:
+    logger = structlog.get_logger()
+    logger.info("Starting home test")
+    device.home()
+
 
 def test_jog(device: WaveplateThorlabsK10CR1) -> None:
+    device.jog(
+        jog_direction=JogDirection.FORWARD,
+    )
+    device.jog(
+        jog_direction=JogDirection.FORWARD,
+    )
     device.jog(
         jog_direction=JogDirection.FORWARD,
     )

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -16,3 +16,17 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
 def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
     device.move_absolute(0 * pnpq_ureg.degree)
     device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
+
+def test_set_jog_params(device: WaveplateThorlabsK10CR1) -> None:
+    device.set_jog_params(
+        minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
+        acceleration=0 * pnpq_ureg.k10cr1_acceleration,
+        maximum_velocity=10 * pnpq_ureg.k10cr1_velocity,
+    )
+
+    ## Matches get jog_params
+    jog_params = device.get_jog_params()
+
+    assert jog_params["minimum_velocity"] == 0 * pnpq_ureg.k10cr1_velocity
+    assert jog_params["acceleration"] == 0 * pnpq_ureg.k10cr1_acceleration
+    assert jog_params["maximum_velocity"] == 10 * pnpq_ureg.k10cr1_velocity

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -3,7 +3,7 @@ from typing import Generator
 import pytest
 
 from pnpq.apt.connection import AptConnection
-from pnpq.apt.protocol import HomeDirection, JogMode, LimitSwitch, StopMode
+from pnpq.apt.protocol import HomeDirection, JogDirection, JogMode, LimitSwitch, StopMode
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
 
@@ -17,7 +17,7 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
 
 # def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
 #     device.move_absolute(0 * pnpq_ureg.degree)
-    # device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
+#     device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
 
 # def test_jogparams(device: WaveplateThorlabsK10CR1) -> None:
 #     log = structlog.get_logger()
@@ -39,20 +39,49 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
 #     assert jogparams["jog_maximum_velocity"].to("k10cr1_velocity").magnitude == 4
 #     assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
 
+# def test_jog(device: WaveplateThorlabsK10CR1) -> None:
+#     device.set_jogparams(
+#         jog_mode=JogMode.SINGLE_STEP,
+#         jog_step_size=1 * pnpq_ureg.k10cr1_step,
+#         jog_minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
+#         jog_acceleration=30 * pnpq_ureg.degree / pnpq_ureg.second**2,
+#         jog_maximum_velocity= 10 * pnpq_ureg.degree / pnpq_ureg.second,
+#         jog_stop_mode=StopMode.IMMEDIATE,
+#     )
 
-def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
-    log = structlog.get_logger()
-    device.set_homeparams(
-        home_direction=HomeDirection.FORWARD_0,
-        limit_switch=LimitSwitch.HARDWARE_FORWARD,
-        home_velocity=1 * pnpq_ureg.k10cr1_velocity,
-        offset_distance=2 * pnpq_ureg.k10cr1_step,
+#     log = structlog.get_logger()
+#     log.info("Starting jog test!!!")
+
+#     device.jog(
+#         jog_direction=JogDirection.FORWARD,
+#     )
+
+# def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
+    # log = structlog.get_logger()
+    # device.set_homeparams(
+    #     home_direction=HomeDirection.FORWARD_0,
+    #     limit_switch=LimitSwitch.HARDWARE_FORWARD,
+    #     home_velocity=1000000 * pnpq_ureg.k10cr1_velocity,
+    #     offset_distance=2 * pnpq_ureg.k10cr1_step,
+    # )
+
+    # homeparams = device.get_homeparams()
+
+    # assert homeparams["home_direction"] == HomeDirection.FORWARD_0
+    # assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
+    # assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1000000
+    # assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
+
+    # logger = structlog.get_logger()
+    # logger.info("Home parameters test passed", homeparams=homeparams)
+
+
+# def test_home(device: WaveplateThorlabsK10CR1) -> None:
+#     logger = structlog.get_logger()
+#     logger.info("Starting home test")
+#     device.home()
+
+def test_jog(device: WaveplateThorlabsK10CR1) -> None:
+    device.jog(
+        jog_direction=JogDirection.FORWARD,
     )
-
-    homeparams = device.get_homeparams()
-
-    assert homeparams["home_direction"] == HomeDirection.FORWARD_0
-    assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
-    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1
-    assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
-

--- a/hardware_tests/test_thorlabs_k10cr1.py
+++ b/hardware_tests/test_thorlabs_k10cr1.py
@@ -3,9 +3,11 @@ from typing import Generator
 import pytest
 
 from pnpq.apt.connection import AptConnection
+from pnpq.apt.protocol import HomeDirection, JogMode, LimitSwitch, StopMode
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
 
+import structlog
 
 @pytest.fixture(name="device", scope="function")
 def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
@@ -13,20 +15,44 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
         yield WaveplateThorlabsK10CR1(connection=connection)
 
 
-def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
-    device.move_absolute(0 * pnpq_ureg.degree)
-    device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
+# def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
+#     device.move_absolute(0 * pnpq_ureg.degree)
+    # device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
 
-def test_set_jog_params(device: WaveplateThorlabsK10CR1) -> None:
-    device.set_jog_params(
-        minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
-        acceleration=0 * pnpq_ureg.k10cr1_acceleration,
-        maximum_velocity=10 * pnpq_ureg.k10cr1_velocity,
+# def test_jogparams(device: WaveplateThorlabsK10CR1) -> None:
+#     log = structlog.get_logger()
+#     device.set_jogparams(
+#         jog_mode=JogMode.SINGLE_STEP,
+#         jog_step_size=1 * pnpq_ureg.k10cr1_step,
+#         jog_minimum_velocity=0 * pnpq_ureg.k10cr1_velocity,
+#         jog_acceleration=3 * pnpq_ureg.k10cr1_acceleration,
+#         jog_maximum_velocity=4 * pnpq_ureg.k10cr1_velocity,
+#         jog_stop_mode=StopMode.IMMEDIATE,
+#     )
+
+#     jogparams = device.get_jogparams()
+
+#     assert jogparams["jog_mode"] == JogMode.SINGLE_STEP
+#     assert jogparams["jog_step_size"].to("k10cr1_step").magnitude == 1
+#     assert jogparams["jog_minimum_velocity"].to("k10cr1_velocity").magnitude == 0
+#     assert jogparams["jog_acceleration"].to("k10cr1_acceleration").magnitude == 3
+#     assert jogparams["jog_maximum_velocity"].to("k10cr1_velocity").magnitude == 4
+#     assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
+
+
+def test_homeparams(device: WaveplateThorlabsK10CR1) -> None:
+    log = structlog.get_logger()
+    device.set_homeparams(
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.HARDWARE_FORWARD,
+        home_velocity=1 * pnpq_ureg.k10cr1_velocity,
+        offset_distance=2 * pnpq_ureg.k10cr1_step,
     )
 
-    ## Matches get jog_params
-    jog_params = device.get_jog_params()
+    homeparams = device.get_homeparams()
 
-    assert jog_params["minimum_velocity"] == 0 * pnpq_ureg.k10cr1_velocity
-    assert jog_params["acceleration"] == 0 * pnpq_ureg.k10cr1_acceleration
-    assert jog_params["maximum_velocity"] == 10 * pnpq_ureg.k10cr1_velocity
+    assert homeparams["home_direction"] == HomeDirection.FORWARD_0
+    assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
+    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1
+    assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2
+

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -182,6 +182,7 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
     _chan_ident = ChanIdent.CHANNEL_1
 
     connection: AptConnection
+    home_on_init: bool = field(default=True)
 
     # Polling threads
     tx_poller_thread: threading.Thread = field(init=False)
@@ -211,13 +212,11 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
 
         if homed:
             self.log.info(
-                "[Waveplate] Device is already homed. No need to home on startup."
+                "[Waveplate] Device is already homed, skipping homing on setup."
             )
-        else:
+        elif self.home_on_init:
             # Home the device on startup
-            self.log.info(
-                "[Waveplate] Device not homed. Homing the device on startup..."
-            )
+            self.log.info("[Waveplate] Device is not homed, homing on setup.")
 
             # Set home velocity to 500 times the default amount
             # because the default amount is really slow
@@ -227,6 +226,10 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
             time.sleep(1)
             self.home()
 
+        else:
+            self.log.info(
+                "[Wvaveplate] Device is not homed, but skipping homing on setup because home_on_init is set to False.",
+            )
 
     # Polling thread for sending status update requests
     def tx_poll(self) -> None:

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -211,7 +211,6 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
                 and message.source == Address.GENERIC_USB
             ),
         )
-        print("STATUSMESSAGE", type(status_message))
         assert isinstance(status_message, AptMessage_MGMSG_MOT_GET_STATUSUPDATE)
         homed = status_message.status.HOMED
 

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -228,7 +228,7 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
 
         else:
             self.log.info(
-                "[Wvaveplate] Device is not homed, but skipping homing on setup because home_on_init is set to False.",
+                "[Waveplate] Device is not homed, but skipping homing on setup because home_on_init is set to False.",
             )
 
     # Polling thread for sending status update requests

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -102,6 +102,50 @@ class AbstractWaveplateThorlabsK10CR1(ABC):
         :param maximum_velocity: The maximum velocity.
         """
 
+    @abstractmethod
+    def get_jogparams(self) -> WaveplateJogParams:
+        """Request jog parameters from the device."""
+
+    @abstractmethod
+    def set_jogparams(
+        self,
+        jog_mode: None | JogMode = None,
+        jog_step_size: None | Quantity = None,
+        jog_minimum_velocity: None | Quantity = None,
+        jog_acceleration: None | Quantity = None,
+        jog_maximum_velocity: None | Quantity = None,
+        jog_stop_mode: None | StopMode = None,
+    ) -> None:
+        """Set jog parameters on the device.
+
+        :param jog_mode: The jog mode.
+        :param jog_step_size: The jog step size.
+        :param jog_minimum_velocity: The minimum velocity.
+        :param jog_acceleration: The acceleration.
+        :param jog_maximum_velocity: The maximum velocity.
+        :param jog_stop_mode: The stop mode.
+        """
+
+    @abstractmethod
+    def get_homeparams(self) -> WaveplateHomeParams:
+        """Request home parameters from the device."""
+
+    @abstractmethod
+    def set_homeparams(
+        self,
+        home_direction: None | HomeDirection = None,
+        limit_switch: None | LimitSwitch = None,
+        home_velocity: None | Quantity = None,
+        offset_distance: None | Quantity = None,
+    ) -> None:
+        """Set home parameters on the device.
+
+        :param home_direction: The home direction.
+        :param limit_switch: The limit switch.
+        :param home_velocity: The home velocity.
+        :param offset_distance: The offset distance.
+        """
+
 
 @dataclass(frozen=True, kw_only=True)
 class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
@@ -289,9 +333,11 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
         result: WaveplateJogParams = {
             "jog_mode": params.jog_mode,
             "jog_step_size": params.jog_step_size * pnpq_ureg.k10cr1_step,
-            "jog_minimum_velocity": params.jog_minimum_velocity * pnpq_ureg.k10cr1_velocity,
+            "jog_minimum_velocity": params.jog_minimum_velocity
+            * pnpq_ureg.k10cr1_velocity,
             "jog_acceleration": params.jog_acceleration * pnpq_ureg.k10cr1_acceleration,
-            "jog_maximum_velocity": params.jog_maximum_velocity * pnpq_ureg.k10cr1_velocity,
+            "jog_maximum_velocity": params.jog_maximum_velocity
+            * pnpq_ureg.k10cr1_velocity,
             "jog_stop_mode": params.jog_stop_mode,
         }
         return result
@@ -327,10 +373,18 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
                 source=Address.HOST_CONTROLLER,
                 chan_ident=self._chan_ident,
                 jog_mode=params["jog_mode"],
-                jog_step_size=params["jog_step_size"].to(pnpq_ureg.k10cr1_step).magnitude,
-                jog_minimum_velocity=params["jog_minimum_velocity"].to(pnpq_ureg.k10cr1_velocity).magnitude,
-                jog_acceleration=params["jog_acceleration"].to(pnpq_ureg.k10cr1_acceleration).magnitude,
-                jog_maximum_velocity=params["jog_maximum_velocity"].to(pnpq_ureg.k10cr1_velocity).magnitude,
+                jog_step_size=params["jog_step_size"]
+                .to(pnpq_ureg.k10cr1_step)
+                .magnitude,
+                jog_minimum_velocity=params["jog_minimum_velocity"]
+                .to(pnpq_ureg.k10cr1_velocity)
+                .magnitude,
+                jog_acceleration=params["jog_acceleration"]
+                .to(pnpq_ureg.k10cr1_acceleration)
+                .magnitude,
+                jog_maximum_velocity=params["jog_maximum_velocity"]
+                .to(pnpq_ureg.k10cr1_velocity)
+                .magnitude,
                 jog_stop_mode=params["jog_stop_mode"],
             )
         )
@@ -387,7 +441,11 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
                 chan_ident=self._chan_ident,
                 home_direction=params["home_direction"],
                 limit_switch=params["limit_switch"],
-                home_velocity=params["home_velocity"].to(pnpq_ureg.k10cr1_velocity).magnitude,
-                offset_distance=params["offset_distance"].to(pnpq_ureg.k10cr1_step).magnitude,
+                home_velocity=params["home_velocity"]
+                .to(pnpq_ureg.k10cr1_velocity)
+                .magnitude,
+                offset_distance=params["offset_distance"]
+                .to(pnpq_ureg.k10cr1_step)
+                .magnitude,
             )
         )

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -18,7 +18,6 @@ from ..apt.protocol import (
     AptMessage_MGMSG_MOT_GET_VELPARAMS,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
-    AptMessage_MGMSG_MOT_MOVE_COMPLETED_6_BYTES,
     AptMessage_MGMSG_MOT_MOVE_HOME,
     AptMessage_MGMSG_MOT_MOVE_HOMED,
     AptMessage_MGMSG_MOT_MOVE_JOG,
@@ -150,6 +149,7 @@ class AbstractWaveplateThorlabsK10CR1(ABC):
         :param home_velocity: The home velocity.
         :param offset_distance: The offset distance.
         """
+
 
 @dataclass(frozen=True, kw_only=True)
 class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
@@ -473,7 +473,6 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
         elapsed_time = time.perf_counter() - start_time
         self.log.debug("home command finished", elapsed_time=elapsed_time)
         self.set_channel_enabled(False)
-
 
     def jog(self, jog_direction: JogDirection) -> None:
         self.set_channel_enabled(True)

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1.py
@@ -449,3 +449,4 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
                 .magnitude,
             )
         )
+

--- a/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
+++ b/src/pnpq/devices/refactored_waveplate_thorlabs_k10cr1_stub.py
@@ -6,10 +6,12 @@ from pint import Quantity
 
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
+    WaveplateHomeParams,
+    WaveplateJogParams,
     WaveplateVelocityParams,
 )
 
-from ..apt.protocol import ChanIdent
+from ..apt.protocol import ChanIdent, HomeDirection, JogMode, LimitSwitch, StopMode
 from ..units import pnpq_ureg
 
 
@@ -25,6 +27,8 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
     )
 
     current_velocity_params: WaveplateVelocityParams = field(init=False)
+    current_jog_params: WaveplateJogParams = field(init=False)
+    current_home_params: WaveplateHomeParams = field(init=False)
 
     current_state: dict[ChanIdent, Quantity] = field(init=False)
 
@@ -47,6 +51,31 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
                 "acceleration": 0 * pnpq_ureg.k10cr1_acceleration,
                 "maximum_velocity": 10
                 * pnpq_ureg.k10cr1_velocity,  # Default value set to 10 k10cr1_velocity based on expected operational range
+            },
+        )
+
+        object.__setattr__(
+            self,
+            "current_jog_params",
+            {
+                "jog_mode": JogMode.SINGLE_STEP,
+                "jog_step_size": 1 * pnpq_ureg.k10cr1_step,
+                "jog_minimum_velocity": 0 * pnpq_ureg.k10cr1_velocity,
+                "jog_acceleration": 0 * pnpq_ureg.k10cr1_acceleration,
+                "jog_maximum_velocity": 10
+                * pnpq_ureg.k10cr1_velocity,  # Default value set to 10 k10cr1_velocity based on expected operational range
+                "jog_stop_mode": StopMode.IMMEDIATE,
+            },
+        )
+
+        object.__setattr__(
+            self,
+            "current_home_params",
+            {
+                "home_direction": HomeDirection.FORWARD_0,
+                "limit_switch": LimitSwitch.HARDWARE_FORWARD,
+                "home_velocity": 0 * pnpq_ureg.k10cr1_velocity,
+                "offset_distance": 0 * pnpq_ureg.k10cr1_step,
             },
         )
 
@@ -83,3 +112,67 @@ class WaveplateThorlabsK10CR1Stub(AbstractWaveplateThorlabsK10CR1):
         self.log.info(
             f"[K10CR1 Stub] Updated parameters: {self.current_velocity_params}"
         )
+
+    def get_jogparams(self) -> WaveplateJogParams:
+        return self.current_jog_params
+
+    def set_jogparams(
+        self,
+        jog_mode: None | JogMode = None,
+        jog_step_size: None | Quantity = None,
+        jog_minimum_velocity: None | Quantity = None,
+        jog_acceleration: None | Quantity = None,
+        jog_maximum_velocity: None | Quantity = None,
+        jog_stop_mode: None | StopMode = None,
+    ) -> None:
+        # There has to be a better way to do this...
+        if jog_mode is not None:
+            self.current_jog_params["jog_mode"] = jog_mode
+
+        if jog_step_size is not None:
+            self.current_jog_params["jog_step_size"] = cast(
+                Quantity, jog_step_size.to("k10cr1_step")
+            )
+        if jog_minimum_velocity is not None:
+            self.current_jog_params["jog_minimum_velocity"] = cast(
+                Quantity, jog_minimum_velocity.to("k10cr1_velocity")
+            )
+        if jog_acceleration is not None:
+            self.current_jog_params["jog_acceleration"] = cast(
+                Quantity, jog_acceleration.to("k10cr1_acceleration")
+            )
+        if jog_maximum_velocity is not None:
+            self.current_jog_params["jog_maximum_velocity"] = cast(
+                Quantity, jog_maximum_velocity.to("k10cr1_velocity")
+            )
+        if jog_stop_mode is not None:
+            self.current_jog_params["jog_stop_mode"] = jog_stop_mode
+
+        # TODO: Remove f string
+        self.log.info(f"[K10CR1 Stub] Updated parameters: {self.current_jog_params}")
+
+    def get_homeparams(self) -> WaveplateHomeParams:
+        return self.current_home_params
+
+    def set_homeparams(
+        self,
+        home_direction: None | HomeDirection = None,
+        limit_switch: None | LimitSwitch = None,
+        home_velocity: None | Quantity = None,
+        offset_distance: None | Quantity = None,
+    ) -> None:
+        if home_direction is not None:
+            self.current_home_params["home_direction"] = home_direction
+        if limit_switch is not None:
+            self.current_home_params["limit_switch"] = limit_switch
+        if home_velocity is not None:
+            self.current_home_params["home_velocity"] = cast(
+                Quantity, home_velocity.to("k10cr1_velocity")
+            )
+        if offset_distance is not None:
+            self.current_home_params["offset_distance"] = cast(
+                Quantity, offset_distance.to("k10cr1_step")
+            )
+
+        # TODO: Remove f string
+        self.log.info(f"[K10CR1 Stub] Updated parameters: {self.current_home_params}")

--- a/src/pnpq/devices/waveplate_thorlabs_kb10crm.py
+++ b/src/pnpq/devices/waveplate_thorlabs_kb10crm.py
@@ -66,6 +66,7 @@ class Waveplate:
         self.hub_connected = check_usb_hub_connected()
 
         self.logger = logging.getLogger(f"USB_HUB{self.hub_connected}")
+
         if self.device_sn is not None:
             self.conn.port = get_available_port(self.device_sn)
             if self.conn.port is None:

--- a/src/pnpq/devices/waveplatetest.py
+++ b/src/pnpq/devices/waveplatetest.py
@@ -1,0 +1,6 @@
+from pnpq.devices.waveplate_thorlabs_kb10crm import Waveplate
+
+print("Hi")
+waveplate = Waveplate(serial_port=None, serial_number="55409764")
+waveplate.connect()
+waveplate.rotate(20)

--- a/src/pnpq/devices/waveplatetest.py
+++ b/src/pnpq/devices/waveplatetest.py
@@ -1,6 +1,0 @@
-from pnpq.devices.waveplate_thorlabs_kb10crm import Waveplate
-
-print("Hi")
-waveplate = Waveplate(serial_port=None, serial_number="55409764")
-waveplate.connect()
-waveplate.rotate(20)

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pnpq.apt.protocol import ChanIdent
+from pnpq.apt.protocol import ChanIdent, HomeDirection, JogMode, LimitSwitch, StopMode
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
 )
@@ -40,3 +40,39 @@ def test_velparams(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
     assert velparams["minimum_velocity"].to("k10cr1_velocity").magnitude == 1
     assert velparams["acceleration"].to("k10cr1_acceleration").magnitude == 2
     assert velparams["maximum_velocity"].to("k10cr1_velocity").magnitude == 3
+
+
+def test_jogparams(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
+    stub_waveplate.set_jogparams(
+        jog_mode=JogMode.SINGLE_STEP,
+        jog_step_size=1 * pnpq_ureg.k10cr1_step,
+        jog_minimum_velocity=2 * pnpq_ureg.k10cr1_velocity,
+        jog_acceleration=3 * pnpq_ureg.k10cr1_acceleration,
+        jog_maximum_velocity=4 * pnpq_ureg.k10cr1_velocity,
+        jog_stop_mode=StopMode.IMMEDIATE,
+    )
+
+    jogparams = stub_waveplate.get_jogparams()
+
+    assert jogparams["jog_mode"] == JogMode.SINGLE_STEP
+    assert jogparams["jog_step_size"].to("k10cr1_step").magnitude == 1
+    assert jogparams["jog_minimum_velocity"].to("k10cr1_velocity").magnitude == 2
+    assert jogparams["jog_acceleration"].to("k10cr1_acceleration").magnitude == 3
+    assert jogparams["jog_maximum_velocity"].to("k10cr1_velocity").magnitude == 4
+    assert jogparams["jog_stop_mode"] == StopMode.IMMEDIATE
+
+
+def test_homeparams(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
+    stub_waveplate.set_homeparams(
+        home_direction=HomeDirection.FORWARD_0,
+        limit_switch=LimitSwitch.HARDWARE_FORWARD,
+        home_velocity=1 * pnpq_ureg.k10cr1_velocity,
+        offset_distance=2 * pnpq_ureg.k10cr1_step,
+    )
+
+    homeparams = stub_waveplate.get_homeparams()
+
+    assert homeparams["home_direction"] == HomeDirection.FORWARD_0
+    assert homeparams["limit_switch"] == LimitSwitch.HARDWARE_FORWARD
+    assert homeparams["home_velocity"].to("k10cr1_velocity").magnitude == 1
+    assert homeparams["offset_distance"].to("k10cr1_step").magnitude == 2

--- a/tests/test_refactored_thorlabs_k10cr1_stub.py
+++ b/tests/test_refactored_thorlabs_k10cr1_stub.py
@@ -1,6 +1,13 @@
 import pytest
 
-from pnpq.apt.protocol import ChanIdent, HomeDirection, JogMode, LimitSwitch, StopMode
+from pnpq.apt.protocol import (
+    ChanIdent,
+    HomeDirection,
+    JogDirection,
+    JogMode,
+    LimitSwitch,
+    StopMode,
+)
 from pnpq.devices.refactored_waveplate_thorlabs_k10cr1 import (
     AbstractWaveplateThorlabsK10CR1,
 )
@@ -26,6 +33,24 @@ def test_move_absolute(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
     waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]  # type: ignore
 
     assert waveplate_position.to("degree").magnitude == pytest.approx(45)
+
+
+def test_jog(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:
+    position = 100 * pnpq_ureg.k10cr1_step
+    stub_waveplate.move_absolute(position)
+    # Using default jog step of 10 steps
+    stub_waveplate.jog(JogDirection.FORWARD)
+
+    # Currently throws a mypy error because current_state is not in the AbstractWaveplateThorlabsK10CR1.
+    # TODO: Replace with get_params when implemented.
+    waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]  # type: ignore
+
+    assert waveplate_position.to("k10cr1_step").magnitude == 110
+    stub_waveplate.jog(JogDirection.REVERSE)
+
+    # Look above
+    waveplate_position = stub_waveplate.current_state[ChanIdent.CHANNEL_1]  # type: ignore
+    assert waveplate_position.magnitude == 100
 
 
 def test_velparams(stub_waveplate: AbstractWaveplateThorlabsK10CR1) -> None:


### PR DESCRIPTION
Assists in closing #104

## Features
* Support many methods for K10CR1 waveplate driver
  * `move_absolute`
  * `get_velparams`
  * `set_velparams`
  * `get_jogparams`
  * `set_jogparams`
  * `get_homeparams`
  * `set_homeparams`
  * `jog`
  * `home`
  * `identify`
  * `is_homed`
* Tested against real device. Also added a feature to automatically home the device if not already homed, to ensure consistency.
* Mock driver not fully implemented, however... I want to check if what I'm doing is correct before going to the mock driver!
