### PR TITLE
Automatically home ODL on init

### DIFF
--- a/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
+++ b/src/pnpq/devices/refactored_odl_thorlabs_kbd101.py
@@ -194,6 +194,7 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
     _chan_ident = ChanIdent.CHANNEL_1
 
     connection: AptConnection
+    home_on_init: bool = field(default=True)
 
     # Polling threads
     tx_poller_thread: threading.Thread = field(init=False)
@@ -223,10 +224,14 @@ class OpticalDelayLineThorlabsKBD101(AbstractOpticalDelayLineThorlabsKBD101):
         is_homed = current_status.status.HOMED
         if is_homed:
             self.log.info("[ODL] Device is already homed, skipping homing on setup.")
-        else:
+        elif self.home_on_init:
             self.log.info("[ODL] Device is not homed, homing on setup.")
             time.sleep(0.1)
             self.home()
+        else:
+            self.log.info(
+                "[ODL] Device is not homed, but skipping homing on setup because home_on_init is set to False.",
+            )
 
     # Polling thread for sending status update requests
     def tx_poll(self) -> None:


### PR DESCRIPTION
Per the title. 
Also, a `home_on_init` flag is added to the class, which can be set to `False` to stop the auto home behavior. 