### PR TITLE
Configuration update for shfmt 3.12.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
+[[shell]]
+simplify = true
+
 [*.py]
 indent_size = 4
 

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -58,7 +58,7 @@ stdmsg "Checking shell scripts with shellcheck..."
 find . -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --enable=all --external-sources
 
 stdmsg "Checking shell script formatting with shfmt..."
-shfmt --diff --simplify .
+shfmt --diff .
 
 stdmsg "Running ruff check..."
 ruff check .


### PR DESCRIPTION
This new version of shfmt ignores editorconfig if `--simplify` is passed, but also allows simplify to be set in .editorconfig. This is a breaking change, but was not marked as such by increasing the major version number (and in fact it's barely mentioned in the changelog, only [this issue](https://github.com/mvdan/sh/issues/1173) explains it well).

I expect that since most people (and the Ubuntu image used by GitHub Actions) aren't on >=3.12, this change will in effect just turn off `--simplify` for most people, but it doesn't seem to make many changes to our code anyway. At some point in the distant future when we upgrade our Ubuntu image we might get some surprise reformatting, but it's unlikely to be a problem.