### PR TITLE
Fix bug with K10CR1 mock not mocking connection properly 

### DIFF
--- a/src/pnpq/devices/waveplate_thorlabs_k10cr1.py
+++ b/src/pnpq/devices/waveplate_thorlabs_k10cr1.py
@@ -589,5 +589,6 @@ class WaveplateThorlabsK10CR1(AbstractWaveplateThorlabsK10CR1):
                 and message.source == Address.GENERIC_USB
             ),
         )
+
         assert isinstance(status_message, AptMessage_MGMSG_MOT_GET_STATUSUPDATE)
         return status_message.status.HOMED

--- a/tests/test_waveplate_thorlabs_k10cr1.py
+++ b/tests/test_waveplate_thorlabs_k10cr1.py
@@ -1,5 +1,8 @@
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import Mock, create_autospec
+
+import pytest
+import structlog
 
 from pnpq.apt.connection import AptConnection
 from pnpq.apt.protocol import (
@@ -8,6 +11,7 @@ from pnpq.apt.protocol import (
     AptMessage_MGMSG_MOT_GET_STATUSUPDATE,
     AptMessage_MGMSG_MOT_MOVE_ABSOLUTE,
     AptMessage_MGMSG_MOT_MOVE_COMPLETED_20_BYTES,
+    AptMessage_MGMSG_MOT_REQ_STATUSUPDATE,
     ChanIdent,
     Status,
     UStatus,
@@ -15,9 +19,27 @@ from pnpq.apt.protocol import (
 from pnpq.devices.waveplate_thorlabs_k10cr1 import WaveplateThorlabsK10CR1
 from pnpq.units import pnpq_ureg
 
+log = structlog.get_logger()
 
-def test_move_absolute() -> None:
+
+@pytest.fixture(name="mock_connection", scope="function")
+def mock_connection_fixture() -> Any:
     connection = create_autospec(AptConnection)
+    connection.stop_event = Mock()
+    connection.tx_ordered_sender_awaiting_reply = Mock()
+    connection.tx_ordered_sender_awaiting_reply.is_set = Mock(return_value=True)
+    return connection
+
+
+def test_move_absolute(mock_connection: Any) -> None:
+    ustatus_message = AptMessage_MGMSG_MOT_GET_STATUSUPDATE(
+        chan_ident=ChanIdent(1),
+        destination=Address.HOST_CONTROLLER,
+        source=Address.GENERIC_USB,
+        enc_count=0,
+        position=0,
+        status=Status(INMOTIONCCW=True, INMOTIONCW=True, HOMED=True),
+    )
 
     def mock_send_message_expect_reply(
         sent_message: AptMessage,
@@ -29,7 +51,6 @@ def test_move_absolute() -> None:
         ],
     ) -> None:
         if isinstance(sent_message, AptMessage_MGMSG_MOT_MOVE_ABSOLUTE):
-
             assert sent_message.absolute_distance == 10
             assert sent_message.chan_ident == ChanIdent(1)
 
@@ -46,27 +67,43 @@ def test_move_absolute() -> None:
 
             assert match_reply_callback(reply_message)
 
-    ustatus_message = AptMessage_MGMSG_MOT_GET_STATUSUPDATE(
-        chan_ident=ChanIdent(1),
-        destination=Address.HOST_CONTROLLER,
-        source=Address.GENERIC_USB,
-        enc_count=0,
-        position=0,
-        status=Status(INMOTIONCCW=True, INMOTIONCW=True, HOMED=True),
-    )
+    def dynamic_mock() -> Callable[..., Any]:
+        call_count = 0
 
-    connection.send_message_expect_reply.side_effect = [
-        ustatus_message,
-        mock_send_message_expect_reply,
-    ]
-    connection.tx_ordered_sender_awaiting_reply = Mock()
-    connection.tx_ordered_sender_awaiting_reply.is_set = Mock(return_value=True)
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
 
-    controller = WaveplateThorlabsK10CR1(connection=connection)
+            if call_count == 1:
+                return ustatus_message
+            if call_count == 2:
+                return mock_send_message_expect_reply(*args, **kwargs)
+            raise RuntimeError("Unexpected call count")
+
+        return side_effect
+
+    mock_connection.send_message_expect_reply.side_effect = dynamic_mock()
+
+    controller = WaveplateThorlabsK10CR1(connection=mock_connection)
 
     controller.move_absolute(10 * pnpq_ureg.k10cr1_step)
+
+    # Assert the message that is sent when K10CR1 initializes and homes
+    first_call_args = mock_connection.send_message_expect_reply.call_args_list[0]
+    assert isinstance(first_call_args[0][0], AptMessage_MGMSG_MOT_REQ_STATUSUPDATE)
+    assert first_call_args[0][0].chan_ident == ChanIdent(1)
+    assert first_call_args[0][0].destination == Address.GENERIC_USB
+    assert first_call_args[0][0].source == Address.HOST_CONTROLLER
+
+    # Assert the message that is sent to move the waveplate
+    second_call_args = mock_connection.send_message_expect_reply.call_args_list[1]
+    assert isinstance(second_call_args[0][0], AptMessage_MGMSG_MOT_MOVE_ABSOLUTE)
+    assert second_call_args[0][0].absolute_distance == 10
+    assert second_call_args[0][0].chan_ident == ChanIdent(1)
+    assert second_call_args[0][0].destination == Address.GENERIC_USB
+    assert second_call_args[0][0].source == Address.HOST_CONTROLLER
 
     # One call for moving the motor.
     # Enabling and disabling the channel doesn't use an expect reply in K10CR1
     # Second call for getting the status update to check if the device is homed
-    assert connection.send_message_expect_reply.call_count == 2
+    assert mock_connection.send_message_expect_reply.call_count == 2


### PR DESCRIPTION
Related to #103 and #104

While adding more methods to `K10CR1`, I ran into an issue with using multiple `side_effect`s on a mock. Specifically, the mocked behavior wasn’t being called correctly when using multiple side effects in a list.

According to the [Python documentation](https://docs.python.org/3.13/library/unittest.mock.html#unittest.mock.Mock.side_effect), `side_effect` can be:

1. A single function or exception: in this case, the mock will call that function or raise that exception.
2. A list or iterable: in this case, the mock will return each item in the list on successive calls.

However, there's a problem. When using a list of side effects (e.g. `[func1, func2]`), the mock does not call each function in sequence. Instead, it just returns the function itself (e.g. returns `func1` on the first call, `func2` on the second), without executing them. That’s not what we want here.  We want the mock to actually run different logic on each call.

So to fix this, I wrote a single function that keeps track of how many times it’s been called and changes its behavior accordingly. This lets us simulate different behaviors across calls while still using `side_effect` as a function, which may be a smart solution or a very dumb one if I'm missing something, haha.

I’m not sure if this is the best or cleanest approach, so I’d appreciate feedback before continuing. 