### PR TITLE
Fuzzy position matching for K10CR move_absolute, better connection error handling

### DIFF
--- a/hardware_tests/conftest.py
+++ b/hardware_tests/conftest.py
@@ -17,7 +17,7 @@ def excepthook(
     e: BaseException,
     traceback: TracebackType | None,
 ) -> Any:
-    log.error(event=Event.UNCAUGHT_EXCEPTION, exc_info=e)
+    log.error(event=Event.UNEXPECTED_EXCEPTION, location="excepthook", exc_info=e)
     return sys.__excepthook__(exception_type, e, traceback)
 
 
@@ -28,7 +28,11 @@ original_threading_excepthook = threading.excepthook
 
 
 def threading_excepthook(args: Any) -> Any:
-    log.error(event=Event.UNCAUGHT_EXCEPTION, exc_info=args.exc_value)
+    log.error(
+        event=Event.UNEXPECTED_EXCEPTION,
+        location="threading_excepthook",
+        exc_info=args.exc_value,
+    )
     return original_threading_excepthook(args)
 
 

--- a/hardware_tests/pnpq/devices/test_waveplate_thorlabs_k10cr1.py
+++ b/hardware_tests/pnpq/devices/test_waveplate_thorlabs_k10cr1.py
@@ -17,7 +17,7 @@ from pnpq.units import pnpq_ureg
 
 log = structlog.get_logger()
 
-SERIAL_NUMBER = "55409764"
+SERIAL_NUMBER = "55528654"
 
 
 def test_connection() -> None:
@@ -50,6 +50,8 @@ def device_fixture() -> Generator[WaveplateThorlabsK10CR1]:
 def test_move_absolute(device: WaveplateThorlabsK10CR1) -> None:
     device.move_absolute(0 * pnpq_ureg.degree)
     device.move_absolute(24575940 * pnpq_ureg.k10cr1_steps)
+    device.move_absolute(179 * pnpq_ureg.degree)
+    device.move_absolute(0 * pnpq_ureg.degree)
 
 
 def test_identify(device: WaveplateThorlabsK10CR1) -> None:

--- a/src/pnpq/apt/connection.py
+++ b/src/pnpq/apt/connection.py
@@ -556,7 +556,7 @@ class AptConnection(AbstractAptConnection):
         # message. This is a little tricky to coordinate in
         # the current architecture.
         with (
-            timeout(300) as check_timeout,
+            timeout(360) as check_timeout,
             self.subscribe() as receive_queue,
         ):
             with self._tx_lock:
@@ -574,7 +574,10 @@ class AptConnection(AbstractAptConnection):
             # block the sending of all messages for a short period of
             # time out of an abundance of caution.
             while check_timeout():
-                message = receive_queue.get(timeout=300)
+                try:
+                    message = receive_queue.get(timeout=1)
+                except Empty:
+                    continue
                 if match_reply(message):
                     reply_queue.put(message)
                     receive_queue.task_done()

--- a/src/pnpq/events.py
+++ b/src/pnpq/events.py
@@ -6,13 +6,14 @@ from enum import StrEnum, auto
 class Event(StrEnum):
     APT_CONNECTION_ERROR = auto()
     APT_POLLER_EXIT = auto()
+    EXPECTED_EXCEPTION = auto()
     RX_MESSAGE_KNOWN = auto()
     RX_MESSAGE_UNKNOWN = auto()
     TX_MESSAGE_ORDERED = auto()
     TX_MESSAGE_ORDERED_EXPECT_REPLY = auto()
     TX_MESSAGE_ORDERED_NO_REPLY = auto()
     TX_MESSAGE_UNORDERED = auto()
-    UNCAUGHT_EXCEPTION = auto()
+    UNEXPECTED_EXCEPTION = auto()
 
     # Common events used by most device types
     DEVICE_CONNECTED = auto()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def excepthook(
     e: BaseException,
     traceback: TracebackType | None,
 ) -> Any:
-    log.error(event=Event.UNCAUGHT_EXCEPTION, exc_info=e)
+    log.error(event=Event.UNEXPECTED_EXCEPTION, location="excepthook", exc_info=e)
     return sys.__excepthook__(exception_type, e, traceback)
 
 
@@ -28,7 +28,11 @@ original_threading_excepthook = threading.excepthook
 
 
 def threading_excepthook(args: Any) -> Any:
-    log.error(event=Event.UNCAUGHT_EXCEPTION, exc_info=args.exc_value)
+    log.error(
+        event=Event.UNEXPECTED_EXCEPTION,
+        location="threading_excepthook",
+        exc_info=args.exc_value,
+    )
     return original_threading_excepthook(args)
 
 


### PR DESCRIPTION
Resolves https://github.com/moonshot-nagayama-pj/PnPQ/issues/173

Based on user reports, it seems like the K10CR2 (and possibly the CR1) sometimes overshoots position 0 when `move_absolute(0)` is called. When it bounces back to the zero-position, it may still register as a few steps away from 0; we saw `MOVE_COMPLETED` messages with a position of -1. As there are are 136,533 steps per each degree of movement, -1 is still extremely close to 0.

This PR adds fuzzy matching, so that anything within +-0.1 degrees of the desired position is considered valid. This way, we can still reject wildly inaccurate moves and eventually signal them as errors.

For a while now (see https://github.com/moonshot-nagayama-pj/PnPQ/issues/173), we have been meaning to fix connection error logging to help make debugging issues like this easier, as some exceptions were disappearing when threads exited; I've added that to this PR as well. Finally, I increased the receive wait timeout from 5 to 6 minutes and made the timeout's behavior easier to understand.