### PR TITLE
Add separate doi: field which GitHub can parse.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,7 @@ authors:
   - given-names: Tom
     family-names: Shen
     orcid: "https://orcid.org/0009-0000-1747-1050"
+doi: 10.5281/zenodo.16886214
 identifiers:
   - type: doi
     value: 10.5281/zenodo.16886214


### PR DESCRIPTION
It turns out that despite all of the official CFF examples not including it, and having comments on their bugtracker saying they want to deprecate it, there's a `doi` field which is the only way to get GitHub to generate citations properly (and it's included in GitHub's docs). Thanks to @PorametPat for the tip.